### PR TITLE
Linux kernel v6.x compatibility

### DIFF
--- a/ax99100_sp.c
+++ b/ax99100_sp.c
@@ -7,7 +7,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This code is modified to support AX99100 series serial devices
  */
 
@@ -62,7 +62,7 @@
 static char version[] =
 KERN_INFO "ASIX AX99100 PCIe Bridg to Serial Port:v" DRV_VERSION
 	"    http://www.asix.com.tw\n";
-	
+
 //All transactions are with memory mapped registers
 #define MEM_AXS 1
 
@@ -174,25 +174,25 @@ struct uart_99100_port {
 	unsigned int 		dma_rx;				//RX DMA enable or not
 	u8			ier; 				//Interrupt Enable Register
 	u8 			lcr;				//Line Control Register
-	u8			mcr;				//Modem Control Register 
+	u8			mcr;				//Modem Control Register
 	u8 			acr;				//Additional Control Register
 	u8			fcr;				//FIFO Control Register
 	int			gier;				//Global Interrupt Enable Register
 	unsigned int		capabilities;			//port capabilities
-	int			rxfifotrigger;		
+	int			rxfifotrigger;
 	int 			txfifotrigger;
 	u32			dma_tx_cnt;			//Amount of data to be DMA in TX
 	u32			dma_rx_cnt;			//Amount of data to be DMA in RX
 	int			first_tx_dma;
-	int			pre_need2recv_cnt;		
+	int			pre_need2recv_cnt;
 	char 	*		dma_tx_buf_v;			//Virtual Address of DMA Buffer for TX
 	dma_addr_t 		dma_tx_buf_p;			//Physical Address of DMA Buffer for TX
-	char 	*		dma_tx_buf_v_start;		//Virtual Address of DMA Buffer for Strat TX 
+	char 	*		dma_tx_buf_v_start;		//Virtual Address of DMA Buffer for Strat TX
 	dma_addr_t 		dma_tx_buf_p_start;		//Physical Address of DMA Buffer for Start TX
 	char	*		dma_rx_buf_v;			//Virtual Address of DMA Buffer for RX
 	dma_addr_t		dma_rx_buf_p;			//Physical Address of DMA Buffer for TX
 	u32			part_done_recv_cnt;		//RX DMA CIRC buffer Read index
-	int 			rx_dma_done_cnt;	
+	int 			rx_dma_done_cnt;
 	int			uart_mode;			//SERIAL TYPE
 	int			flow_control;			//Flow control is enabled or not
 	int			flow_ctrl_type;			//Type of Flow control
@@ -220,11 +220,11 @@ struct uart_99100_port {
 	int 			ltc2872_dz;
 	int 			ltc2872_lb;
 	int 			ltc2872_fen;
-	
+
 	u32			dma_delay_timeout;
 	u32			boundary_check;
 	u32			old_spssr2;
-	
+
 	struct tasklet_struct	tasklet_dma_rx;
 	struct tasklet_struct	tasklet_dma_tx;
 	int			k_gir; /* used in rx_kevent */
@@ -241,23 +241,23 @@ struct uart_99100_port {
 static struct uart_99100_port serial99100_ports[UART99100_NR];
 
 struct uart_99100_contxt {
-	int rx_dma_en;		
+	int rx_dma_en;
 				//0 -I/O mode of RX
 				//1 -DMA mode of RX
-	int tx_dma_en;		
-				//0 -I/O mode of TX 
+	int tx_dma_en;
+				//0 -I/O mode of TX
 				//1 -DMA mode of TX
-	int uart_mode;		
+	int uart_mode;
 				//AX99100_RS232_MODE
 				//AX99100_RS422_MODE
 				//AX99100_RS485_HALF_DUPLEX
 				//AX99100_RS485_HALF_DUPLEX_ECHO
 				//AX99100_RS485_FULL_DUPLEX
 				//AX99100_RS485_FULL_DUPLEX_TXEN
-	int en_flow_control;  
-				//0 -No H/W Flow Control	 
+	int en_flow_control;
+				//0 -No H/W Flow Control
 				//1 -H/W Flow Control
-	int flow_ctrl_type;	
+	int flow_ctrl_type;
 				//AX99100_DTR_DSR_HW_FLOWCONTROL
 				//AX99100_XON_XOFF_HW_FLOWCONTROL
 				//AX99100_RTS_CTS_HW_FLOWCONTROL
@@ -270,7 +270,7 @@ struct uart_99100_contxt {
 	int ltc2872_te485;	//0 -open
 				//1 -enable 120Ohm TX termination
 	int ltc2872_dz;		//0 -open
-				//1 -enable 120Ohm RX termination 
+				//1 -enable 120Ohm RX termination
 	int ltc2872_lb;		//0 -disable loopback
 				//1 -enable loopback
 	int ltc2872_fen;	//0 -disable fast mode
@@ -295,7 +295,7 @@ static struct uart_99100_contxt uart_99100_contxts[] = {
 		.en_flow_control= 0,
 		.flow_ctrl_type = AX99100_RTS_CTS_HW_FLOWCONTROL,
 		.rxfifotrigger	= 1,
-		.txfifotrigger	= 1,		
+		.txfifotrigger	= 1,
 		.x_on		= SERIAL_DEF_XON,
 		.x_off		= SERIAL_DEF_XOFF,
 
@@ -316,7 +316,7 @@ static struct uart_99100_contxt uart_99100_contxts[] = {
 		.en_flow_control= 0,
 		.flow_ctrl_type = AX99100_RTS_CTS_HW_FLOWCONTROL,
 		.rxfifotrigger  = 1,
-		.txfifotrigger  = 1,		
+		.txfifotrigger  = 1,
 		.x_on		= SERIAL_DEF_XON,
 		.x_off		= SERIAL_DEF_XOFF,
 
@@ -327,7 +327,7 @@ static struct uart_99100_contxt uart_99100_contxts[] = {
 		.pci_config_l0s	= 0,
 		.pci_config_l1 	= 0,
 		.mode_9bit	= MODE_9BIT_DISABLE,
-		.nodeID_9bit	= 0,		
+		.nodeID_9bit	= 0,
 	},
 	//Port 2
 	{
@@ -337,7 +337,7 @@ static struct uart_99100_contxt uart_99100_contxts[] = {
 		.en_flow_control= 0,
 		.flow_ctrl_type = AX99100_RTS_CTS_HW_FLOWCONTROL,
 		.rxfifotrigger	= 1,
-		.txfifotrigger	= 1,		
+		.txfifotrigger	= 1,
 		.x_on		= SERIAL_DEF_XON,
 		.x_off		= SERIAL_DEF_XOFF,
 
@@ -358,7 +358,7 @@ static struct uart_99100_contxt uart_99100_contxts[] = {
 		.en_flow_control= 0,
 		.flow_ctrl_type = AX99100_RTS_CTS_HW_FLOWCONTROL,
 		.rxfifotrigger	= 1,
-		.txfifotrigger	= 1,		
+		.txfifotrigger	= 1,
 		.x_on		= SERIAL_DEF_XON,
 		.x_off		= SERIAL_DEF_XOFF,
 
@@ -482,7 +482,7 @@ void setserial_ENHANC_mode(struct uart_99100_port *up)
 	efr |= UART_EFR_ECB;
 	serial_out(up, UART_EFR,efr);
 
-	serial_out(up, UART_LCR, lcr);	
+	serial_out(up, UART_LCR, lcr);
 
 	DEBUG("In %s---------------------------------------END\n",__FUNCTION__);
 }
@@ -501,13 +501,9 @@ static inline void serial99100_clear_fifos(struct uart_99100_port *p)
 //Helper function to set the the UART to sleep mode
 static inline void serial99100_set_sleep(struct uart_99100_port *p, int sleep)
 {
-	unsigned char lcr = 0, efr = 0;
-	
 	DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);
 	if (p->capabilities & UART_CAP_SLEEP) {
 		if (p->capabilities & UART_CAP_EFR) {
-			lcr = serial_in(p, UART_LCR);
-			efr = serial_in(p, UART_EFR);
 			serial_out(p, UART_LCR, 0xBF);
 			serial_out(p, UART_EFR, UART_EFR_ECB);
 			serial_out(p, UART_LCR, 0);
@@ -515,8 +511,8 @@ static inline void serial99100_set_sleep(struct uart_99100_port *p, int sleep)
 		serial_out(p, UART_IER, sleep ? UART_IERX_SLEEP : 0);
 		if (p->capabilities & UART_CAP_EFR) {
 			serial_out(p, UART_LCR, 0xBF);
-			serial_out(p, UART_EFR, efr);
-			serial_out(p, UART_LCR, lcr);
+			serial_out(p, UART_EFR, 0);
+			serial_out(p, UART_LCR, 0);
 		}
 	}
 	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
@@ -530,7 +526,7 @@ static void serial99100_stop_tx(struct uart_port *port)
 #endif
 {
 	struct uart_99100_port *up = &serial99100_ports[port->line];
-	u32	value=0;	
+	u32	value=0;
 	DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);
 
 	if(up->dma_tx){
@@ -563,22 +559,22 @@ static void serial99100_start_tx(struct uart_port *port)
 	u32	length=0,len2end,txdma_status=0;
 	int tail,head,tobe_transferred;
 	unsigned long flags;
-	
+
 	D_T_DEBUG("In %s ---------0x%x\n",__FUNCTION__,readl(up->port.membase+REG_TX_DMA_STATUS));
 	TX_DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);
-	
+
 	if (up->first_tx_dma == 1) {
 		txdma_status = 1;
 		up->first_tx_dma = 0;
 	} else
 		txdma_status = readl(up->port.membase+REG_TX_DMA_STATUS);
-	
+
 	D_T_DEBUG("In %s ---------0x%x\n",__FUNCTION__,txdma_status);
 	tobe_transferred=readl(up->port.membase+REG_TX_BYTES_TRANSFERRED);
 	DMATX_DEBUG("In %s -------------tobe_transferred=%d--------------------------START\n",__FUNCTION__,tobe_transferred);
-	
-	if(up->dma_tx && ((txdma_status & 0x01) == 1) && up->serialise_txdma == 0){	  
-		
+
+	if(up->dma_tx && ((txdma_status & 0x01) == 1) && up->serialise_txdma == 0){
+
 		TX_DEBUG(" I WAS IN DMA OF START_TX\n");
 
 		//CALCULATING THE AMOUNT OF DATA AVAILABLE FOR THE NEXT TRANSFER
@@ -593,8 +589,8 @@ static void serial99100_start_tx(struct uart_port *port)
 		head=xmit->head;
 		tail=xmit->tail;
 		len2end = CIRC_CNT_TO_END(head, tail, UART_XMIT_SIZE); //size 4096
-		TX_DEBUG("In %s -------------------xmit->tail=%d, xmit->head=%d,length=%d,length2end=%d\n",__FUNCTION__,tail,head,length,len2end);			
-				
+		TX_DEBUG("In %s -------------------xmit->tail=%d, xmit->head=%d,length=%d,length2end=%d\n",__FUNCTION__,tail,head,length,len2end);
+
 		if(tail < head){
 			if(length <= DMA_TX_BUFFER_SZ){
 				TX_DEBUG("In %s normal circ buffer\n",__FUNCTION__);
@@ -625,7 +621,7 @@ static void serial99100_start_tx(struct uart_port *port)
 					up->dma_tx_cnt = DMA_TX_BUFFER_SZ;
 				}
 			}
-		}		
+		}
 
 		DMATX_DEBUG("In %s -------------xmit->tail=%d--------------------------START\n",__FUNCTION__,xmit->tail);
 		xmit->tail = ((xmit->tail) + up->dma_tx_cnt) & (UART_XMIT_SIZE-1);
@@ -633,15 +629,15 @@ static void serial99100_start_tx(struct uart_port *port)
 
 		up->serialise_txdma++;
 
-spin_lock_irqsave(&up->lock_99100, flags);			
-		//variable to serialise the DMA tx calls	
+spin_lock_irqsave(&up->lock_99100, flags);
+		//variable to serialise the DMA tx calls
 		writel(up->dma_tx_buf_p_start,up->port.membase + REG_TX_DMA_START_ADDRESS_LOW);
 		writel(up->dma_tx_cnt,up->port.membase+REG_TX_DMA_LENGTH);
-		writel(TX_DMA_START_BIT, up->port.membase + REG_TX_DMA_START);	
+		writel(TX_DMA_START_BIT, up->port.membase + REG_TX_DMA_START);
 spin_unlock_irqrestore(&up->lock_99100, flags);
-		
-		TX_DEBUG("In %s programmed registers\n",__FUNCTION__);		
-		//UPDATING THE xmit FIFO WITH THE AMOUNT OF DATA TRANSFERRED		
+
+		TX_DEBUG("In %s programmed registers\n",__FUNCTION__);
+		//UPDATING THE xmit FIFO WITH THE AMOUNT OF DATA TRANSFERRED
 		txdma_status=0;
 	}else{
 		if (!(up->ier & UART_IER_THRI)) {
@@ -649,7 +645,7 @@ spin_unlock_irqrestore(&up->lock_99100, flags);
 			serial_out(up, UART_IER, up->ier);
 		}
  	}
-	 
+
  	TX_DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
 }
 
@@ -658,7 +654,7 @@ static void serial99100_stop_rx(struct uart_port *port)
 {
 	struct uart_99100_port *up = &serial99100_ports[port->line];
 	//u32	value=0;
-	
+
 	DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);
 	if(up->dma_rx){
 		//value |= RX_DMA_STOP_BIT;
@@ -667,7 +663,7 @@ static void serial99100_stop_rx(struct uart_port *port)
 		up->ier &= ~UART_IER_RLSI;
 		up->port.read_status_mask &= ~UART_LSR_DR;
 		serial_out(up, UART_IER, up->ier);
-	}	
+	}
 	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
 }
 
@@ -694,7 +690,7 @@ static void serial99100_disable_ms(struct uart_port *port)
 //Function to check modem statuss
 static _INLINE_ void check_modem_status(struct uart_99100_port *up)
 {
-	u8 status;	
+	u8 status;
 
 	DEBUG("In %s -------------------- START\n",__FUNCTION__);
 	status = serial_in(up, UART_MSR);
@@ -756,7 +752,7 @@ static _INLINE_ void receive_chars(struct uart_99100_port *up, u8 *status, struc
 			 */
 		}
 		#endif
-		ch = serial_in(up, UART_RX);		
+		ch = serial_in(up, UART_RX);
 		flag = TTY_NORMAL;
 		up->port.icount.rx++;
 
@@ -787,7 +783,7 @@ static _INLINE_ void receive_chars(struct uart_99100_port *up, u8 *status, struc
 			/*
 			 * Mask off conditions which should be ignored.
 			 */
-			lsr &= up->port.read_status_mask;			
+			lsr &= up->port.read_status_mask;
 
 			if (lsr & UART_LSR_BI) {
 				DEBUG("handling break....");
@@ -822,12 +818,12 @@ static _INLINE_ void receive_chars(struct uart_99100_port *up, u8 *status, struc
 			} else {
 				if (up->enable_slave_9bit == 1) {
 				//printk("%s - S0 char: %x PE: %x \n", __FUNCTION__ , ch, lsr_PE);
-					uart_insert_char(&up->port, 
+					uart_insert_char(&up->port,
 							lsr,
 							UART_LSR_OE, ch, flag);
-				}				
-			}			
-			
+				}
+			}
+
 		} else if (up->mode_9bit == MODE_9BIT_MASTER) {
 			//printk("%s - M char: %x Flag: %x \n", __FUNCTION__ , ch, flag);
 			if (!lsr_PE) {
@@ -839,11 +835,11 @@ static _INLINE_ void receive_chars(struct uart_99100_port *up, u8 *status, struc
 			//printk("%s - char: %x PE: %x \n", __FUNCTION__ , ch, lsr_PE);
 			uart_insert_char(&up->port, lsr, UART_LSR_OE, ch, flag);
 		}
-		
+
 ignore_char:
 
 		lsr = serial_in(up, UART_LSR);
-	} while ((lsr & UART_LSR_DR) && (max_count-- > 0));	
+	} while ((lsr & UART_LSR_DR) && (max_count-- > 0));
 	spin_unlock(&up->port.lock);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,0)
 	tty_flip_buffer_push(tty->port);
@@ -851,7 +847,7 @@ ignore_char:
 	tty_flip_buffer_push(tty);
 #endif
 	spin_lock(&up->port.lock);
-	
+
 	*status = lsr;
 	DEBUG("In %s -------------------------------------END\n",__FUNCTION__);
 }
@@ -880,7 +876,7 @@ static _INLINE_ void transmit_chars(struct uart_99100_port *up)
 		serial99100_stop_tx(&up->port, 0);
 		#else
 		serial99100_stop_tx(&up->port);
-		#endif		
+		#endif
 		return;
 	}
 
@@ -924,7 +920,7 @@ static void transmit_chars_dma_stop_done(struct uart_99100_port * up)
 		xmit->tail=((xmit->tail)+transferred) & (UART_XMIT_SIZE-1);
 		up->port.icount.tx += transferred;
 		up->serialise_txdma=0;
-		
+
 		memset(up->dma_tx_buf_v,0,DMA_TX_BUFFER_SZ);
 		DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
 }
@@ -939,45 +935,45 @@ static int transmit_chars_dma_done(struct uart_99100_port * up)
 	struct circ_buf *xmit = &up->port.state->xmit;
 #endif
 	int length,len2end;
-	
-	
+
+
 	D_T_DEBUG("In %s ---------0x%x\n",__FUNCTION__,readl(up->port.membase+REG_TX_DMA_STATUS));
 	DMATX_DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);
 
-	up->port.icount.tx += up->dma_tx_cnt;			
-	length = uart_circ_chars_pending(xmit); 
-	DMATX_DEBUG("In %s circ_buf lenght=%d after\n",__FUNCTION__,length); 
-	
+	up->port.icount.tx += up->dma_tx_cnt;
+	length = uart_circ_chars_pending(xmit);
+	DMATX_DEBUG("In %s circ_buf lenght=%d after\n",__FUNCTION__,length);
+
 	DMATX_DEBUG("In %s up->dma_tx_buf_v=0x%x ---------------------------------------\n",__FUNCTION__,(unsigned int)up->dma_tx_buf_v);
-		
+
 	if (uart_circ_empty(xmit) || uart_tx_stopped(&up->port)){
-		up->serialise_txdma=0;			
+		up->serialise_txdma=0;
 		if (length < WAKEUP_CHARS)
 			uart_write_wakeup(&up->port);
-		return 0;		
+		return 0;
 	}
 
-	//CALCULATING THE AMOUNT OF DATA AVAILABLE FOR THE NEXT TRANSFER 
+	//CALCULATING THE AMOUNT OF DATA AVAILABLE FOR THE NEXT TRANSFER
 	//AND COPYING THE DATA TO THE DMA BUFFER
-	
+
 	length = uart_circ_chars_pending(xmit);
-	len2end = CIRC_CNT_TO_END(xmit->head, xmit->tail, UART_XMIT_SIZE); 
+	len2end = CIRC_CNT_TO_END(xmit->head, xmit->tail, UART_XMIT_SIZE);
 	DMATX_DEBUG("In %s -------xmit->tail=%d, xmit->head=%d,length=%d,length2end=%d\n",__FUNCTION__,xmit->tail,xmit->head,length,len2end);
-	
-	if(xmit->tail < xmit->head){	
+
+	if(xmit->tail < xmit->head){
 		if(length <= DMA_TX_BUFFER_SZ){
 			memcpy(up->dma_tx_buf_v,&xmit->buf[xmit->tail],length);  //xmit->buf + xmit->tail
 			D_T_DEBUG("In %s ---1-----0x%x\n",__FUNCTION__,readl(up->port.membase+REG_TX_DMA_STATUS));
 			up->dma_tx_cnt = length;
-			DMATX_DEBUG("In %s Normal mode\n",__FUNCTION__); 
+			DMATX_DEBUG("In %s Normal mode\n",__FUNCTION__);
 		}else{
 			memcpy(up->dma_tx_buf_v,&xmit->buf[xmit->tail],DMA_TX_BUFFER_SZ);
 			D_T_DEBUG("In %s ---1-----0x%x\n",__FUNCTION__,readl(up->port.membase+REG_TX_DMA_STATUS));
 			up->dma_tx_cnt = DMA_TX_BUFFER_SZ;
-		}	
+		}
 	}else{
 		if(length <= DMA_TX_BUFFER_SZ){
-			DMATX_DEBUG("In %s 2nd mode\n",__FUNCTION__); 
+			DMATX_DEBUG("In %s 2nd mode\n",__FUNCTION__);
 			memcpy(up->dma_tx_buf_v,&xmit->buf[xmit->tail],len2end);
 			memcpy(up->dma_tx_buf_v+len2end,xmit->buf,xmit->head);
 			D_T_DEBUG("In %s ---1-----0x%x\n",__FUNCTION__,readl(up->port.membase+REG_TX_DMA_STATUS));
@@ -992,36 +988,36 @@ static int transmit_chars_dma_done(struct uart_99100_port * up)
 				memcpy(up->dma_tx_buf_v,&xmit->buf[xmit->tail],DMA_TX_BUFFER_SZ);
 				D_T_DEBUG("In %s ---1-----0x%x\n",__FUNCTION__,readl(up->port.membase+REG_TX_DMA_STATUS));
 				up->dma_tx_cnt = DMA_TX_BUFFER_SZ;
-			}	
+			}
 		}
 	}
-	
+
 	//UPDATING THE xmit FIFO WITH THE AMOUNT OF DATA TRANSFERRED
 	DMATX_DEBUG("In %s -------------xmit->tail=%d--------------------------START\n",__FUNCTION__,xmit->tail);
 	xmit->tail = ((xmit->tail) + up->dma_tx_cnt) & (UART_XMIT_SIZE-1);
 	DMATX_DEBUG("In %s -------------xmit->tail2=%d--------------------------START\n",__FUNCTION__,xmit->tail);
-	
+
 
 	DMATX_DEBUG("In %s length=%d\n",__FUNCTION__,length);
-	
-	
+
+
 	//INITIATING THE NEXT TRANSFER
-	writel(up->dma_tx_buf_p,up->port.membase + REG_TX_DMA_START_ADDRESS_LOW);	
-	//Writing the length of data to the TX DMA Length register	
+	writel(up->dma_tx_buf_p,up->port.membase + REG_TX_DMA_START_ADDRESS_LOW);
+	//Writing the length of data to the TX DMA Length register
 	writel(up->dma_tx_cnt,up->port.membase+REG_TX_DMA_LENGTH);
 	//Start the DMA data transfer
 	writel(TX_DMA_START_BIT,up->port.membase+REG_TX_DMA_START);
 
 	D_T_DEBUG("In %s ---1-----0x%x\n",__FUNCTION__,readl(up->port.membase+REG_TX_DMA_STATUS));
-	
-	up->serialise_txdma=0;	
-	
+
+	up->serialise_txdma=0;
+
 	// Requesting more data to send out from the TTY layer to the driver
 	if (length < WAKEUP_CHARS)
-		uart_write_wakeup(&up->port);	
-	
+		uart_write_wakeup(&up->port);
+
 	DMATX_DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
-	
+
 	return 0;
 }
 
@@ -1038,13 +1034,13 @@ static void receive_chars_dma_done(struct uart_99100_port * up, int iirg)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	u8 ch;
 #endif
-	int i;		
+	int i;
 	u32 received_bytes;
 	u32 need2recv,temp_spssr2=0;
 
 	up->k_lsr = serial_in(up, UART_LSR);
-	
-	
+
+
 	RXDMA_DBG("In %s ---------iirg=0x%x------------------------------START\n",__FUNCTION__,iirg);
 	//checking for the flip buffer size and asking to clear it upon some threshold
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,15)
@@ -1058,47 +1054,47 @@ static void receive_chars_dma_done(struct uart_99100_port * up, int iirg)
 #endif
 	need2recv=readl(up->port.membase + REG_RX_BYTES_NEED_TO_RECV);
 	RXDMA_DBG("In %s --------Receive DMA Part Done need2recv=%d\n",__FUNCTION__,need2recv);
-	RXDMA_DBG("In %s --------pre_need2recv_cnt=%d\n",__FUNCTION__,up->pre_need2recv_cnt);	
-	
+	RXDMA_DBG("In %s --------pre_need2recv_cnt=%d\n",__FUNCTION__,up->pre_need2recv_cnt);
+
 	if ( need2recv == 0 && up->pre_need2recv_cnt == 0) {
 		if (iirg & SPINTR_RXDMA_COMPLETE_ISR && !(iirg & SPINTR_RXDMA_DONE))
 			goto COMPLETED;
 	}
-	
+
 	up->pre_need2recv_cnt = need2recv;
-	
+
 	if ((iirg & SPINTR_RXDMA_DONE || iirg & SPINTR_RXDMA_COMPLETE_ISR)){
-	  
+
 		if (up->rx_dma_done_cnt == (DMA_RX_BUFFER_SZ/DMA_RX_SZ)){
 			up->rx_dma_done_cnt=0;
 		}
-		
-		if (up->rx_dma_done_cnt == 0) 
+
+		if (up->rx_dma_done_cnt == 0)
 			received_bytes=(DMA_RX_SZ -(need2recv + up->part_done_recv_cnt));
 		else
-			received_bytes=(DMA_RX_BUFFER_SZ -(need2recv + up->part_done_recv_cnt));		
-					
+			received_bytes=(DMA_RX_BUFFER_SZ -(need2recv + up->part_done_recv_cnt));
+
 		//copiying the recived bytes to the TTY layers flip buffer
 		if (tty){
-			
+
 			for (i = 1; i <= received_bytes; i++){
 				/* if we insert more than TTY_FLIPBUF_SIZE characters, tty layer will drop them. */
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,15)
 				if(tty->flip.count >= TTY_FLIPBUF_SIZE){
 					tty_flip_buffer_push(tty);
 				}
-#endif				
+#endif
 				if (uart_handle_sysrq_char(&up->port, ch))
 					goto ignore_char;
 
-				/* this doesn't actually push the data through unless tty->low_latency is set */					
+				/* this doesn't actually push the data through unless tty->low_latency is set */
 				uart_insert_char(&up->port, up->k_lsr, UART_LSR_OE, up->dma_rx_buf_v[up->part_done_recv_cnt], TTY_NORMAL);
 ignore_char:
 				up->part_done_recv_cnt++;
 
 				if(up->part_done_recv_cnt == DMA_RX_BUFFER_SZ)
-					up->part_done_recv_cnt = 0;				
-			}				
+					up->part_done_recv_cnt = 0;
+			}
 
 		}
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,0)
@@ -1119,34 +1115,34 @@ ignore_char:
 		up->boundary_check = 1;
 		temp_spssr2=readl(up->port.membase+SP_SETTING_REG2);
 		up->old_spssr2=temp_spssr2;
-			
+
 		temp_spssr2&=0x03ffffff;
 		temp_spssr2|=0x03fffc00;
-		writel(temp_spssr2,up->port.membase+SP_SETTING_REG2);		
+		writel(temp_spssr2,up->port.membase+SP_SETTING_REG2);
 	}
-	
+
 COMPLETED:
 	if (iirg & SPINTR_RXDMA_COMPLETE_ISR) {
-			
+
 		up->pre_need2recv_cnt = DMA_RX_SZ;
 		up->boundary_check = 0;
-		
-		if (up->rx_dma_done_cnt == 0) 
+
+		if (up->rx_dma_done_cnt == 0)
 			up->dma_start_offset = DMA_RX_SZ;
-		else 
+		else
 			up->dma_start_offset = 0;
-		
+
 		//Reinitialise the DMA
 		writel(up->dma_rx_buf_p + up->dma_start_offset, up->port.membase + REG_RX_DMA_START_ADDRESS_LOW);
 		//writel(0,up->port.membase+REG_RX_DMA_START_ADDRESS_HIGH);
-		writel(DMA_RX_SZ,up->port.membase+REG_RX_DMA_LENGTH);			
+		writel(DMA_RX_SZ,up->port.membase+REG_RX_DMA_LENGTH);
 		writel(RX_DMA_START_BIT,up->port.membase+REG_RX_DMA_START);
-		
-		writel(up->old_spssr2,up->port.membase+SP_SETTING_REG2);			
-			
+
+		writel(up->old_spssr2,up->port.membase+SP_SETTING_REG2);
+
 		up->rx_dma_done_cnt++;
-	}	
-	
+	}
+
 }
 
 
@@ -1170,15 +1166,15 @@ static inline void serial99100_handle_port(struct uart_99100_port *up, struct pt
 	#else
 		receive_chars(up, &status, regs);
 	#endif
-	
+
 	}
-	
+
 	if ((status & UART_LSR_THRE) && !up->dma_tx){
 		DEBUG("TRANSMIT_CHARS\n");
 		transmit_chars(up);
 	}
-	
-	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);	
+
+	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
 }
 
 
@@ -1193,38 +1189,38 @@ static irqreturn_t serial99100_interrupt(int irq, void *dev_id, struct pt_regs *
 	struct uart_99100_port *up = dev_id;
 	u32 gir=0;
 	u8 iir=0;
-	int handled=0;	
-	
-	if (suspend_count == 4 && ((gpio_mode == GPIO_4MP_MODE) || (gpio_mode == GPIO_2S_2MP_MODE) 
+	int handled=0;
+
+	if (suspend_count == 4 && ((gpio_mode == GPIO_4MP_MODE) || (gpio_mode == GPIO_2S_2MP_MODE)
 				|| (gpio_mode == GPIO_4S_MODE)))
 		gir = 0;
 	else
 		gir= readl(up->port.membase+ REG_GLBL_ISR);
-	
+
 	//clear glbl int
-	writel(gir,up->port.membase+REG_GLBL_ICLR);	
+	writel(gir,up->port.membase+REG_GLBL_ICLR);
 
 	//if (gir == 0)
 	//	return IRQ_RETVAL(0);
-		
+
 	//DMA RX
-	if (gir & SPINTR_RXDMA) {		
+	if (gir & SPINTR_RXDMA) {
 		up->k_gir = gir & SPINTR_RXDMA;
 		tasklet_schedule(&up->tasklet_dma_rx);
-		handled=1;			
-	} 
+		handled=1;
+	}
 	//DMA TX
 	if (gir & SPINTR_TXDMA_ISR) {
 		tasklet_schedule(&up->tasklet_dma_tx);
 		handled=1;
-	} 
-	
+	}
+
 	//FIFO
-	if (gir & SPINTR_ISR) {				
+	if (gir & SPINTR_ISR) {
 		iir = serial_in(up, UART_IIR);
-		if (!(iir & UART_IIR_NO_INT)) {			
+		if (!(iir & UART_IIR_NO_INT)) {
 			spin_lock(&up->port.lock);
-			
+
 			if ((iir & 0x3F) == 0x0) {
 				check_modem_status(up);
 			} else {
@@ -1232,11 +1228,11 @@ static irqreturn_t serial99100_interrupt(int irq, void *dev_id, struct pt_regs *
 				serial99100_handle_port(up);
 #else
 				serial99100_handle_port(up, regs);
-#endif	
+#endif
 			}
 			spin_unlock(&up->port.lock);
 			handled = 1;
-		}		
+		}
 	}
 
 	return IRQ_RETVAL(handled);
@@ -1254,7 +1250,7 @@ static unsigned int serial99100_tx_empty(struct uart_port *port)
 	ret = serial_in(up, UART_LSR) & UART_LSR_TEMT ? TIOCSER_TEMT : 0;
 	spin_unlock_irqrestore(&up->lock_99100, flags);
 	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
-	
+
 	return ret;
 }
 
@@ -1278,8 +1274,8 @@ static unsigned int serial99100_get_mctrl(struct uart_port *port)
 	if (status & UART_MSR_DSR)
 		ret |= TIOCM_DSR;
 	if (status & UART_MSR_CTS)
-		ret |= TIOCM_CTS;	
-	
+		ret |= TIOCM_CTS;
+
 	return ret;
 }
 
@@ -1300,7 +1296,7 @@ static void serial99100_set_mctrl(struct uart_port *port, unsigned int mctrl)
 		mcr |= UART_MCR_OUT2;
 	if (mctrl & TIOCM_LOOP)
 		mcr |= UART_MCR_LOOP;
-	
+
 	mcr |= up->mcr;
 
 	serial_out(up, UART_MCR, mcr);
@@ -1349,10 +1345,10 @@ static int serial99100_startup(struct uart_port *port)
 
 	up->capabilities = uart_config[up->port.type].flags;
 	up->mcr = 0;
-	up->part_done_recv_cnt = 0;	
+	up->part_done_recv_cnt = 0;
 	up->rx_dma_done_cnt = 0;
 	up->dma_start_offset = 0;
-	up->first_tx_dma = 1;	
+	up->first_tx_dma = 1;
 	up->boundary_check = 0;
 	up->old_spssr2 = 0;
 	up->serialise_txdma = 0;
@@ -1368,8 +1364,8 @@ static int serial99100_startup(struct uart_port *port)
 	 */
 	if(up->dma_tx || up->dma_rx)
 		(void) writel(0xFF,up->port.membase+REG_GLBL_ICLR);
-	
-		
+
+
 	(void) serial_in(up, UART_LSR);
 	(void) serial_in(up, UART_RX);
 	(void) serial_in(up, UART_IIR);
@@ -1379,7 +1375,7 @@ static int serial99100_startup(struct uart_port *port)
 	 */
 	serial_out(up, UART_LCR, UART_LCR_WLEN8);
 
-	spin_lock_irqsave(&up->lock_99100, flags);	
+	spin_lock_irqsave(&up->lock_99100, flags);
 	up->port.mctrl |= TIOCM_OUT2;
 	serial99100_set_mctrl(&up->port, up->port.mctrl);
 	spin_unlock_irqrestore(&up->lock_99100, flags);
@@ -1388,31 +1384,31 @@ static int serial99100_startup(struct uart_port *port)
 	//Rx data transfer Interrupts
 	up->ier = UART_IER_RLSI | UART_IER_RDI;
 	serial_out(up, UART_IER, up->ier);
-	
+
 	//up->ier |= UART_IER_MSI;
 	//serial_out(up, UART_IER, up->ier);
-	
+
 	/* ASUS setting */
 	if ((CusEEbuffer.cus_mod == CUS_ASUS) && (up->function_number > 1))
 		serial99100_serialSettingGPIO(up);
-	
+
 	if(up->port.type == PORT_16550A){
 		DEBUG("In %s 550EX mode\n",__FUNCTION__);
 		ser_dcr_din_val=readl(up->port.membase+SP_SETTING_REG0);
 		ser_dcr_din_val |= COM_550EX_MODE_EN;
 		writel(ser_dcr_din_val,up->port.membase+SP_SETTING_REG0);
 		DEBUG("In %s 550EX mode SP_SETTING_REG0=0x%x\n",__FUNCTION__,readl(up->port.membase+SP_SETTING_REG0));
-	
+
 		if(up->flow_control){
 			DEBUG("Enabled the Auto Hardware Flowcontrol\n");
 			mcr = serial_in(up,UART_MCR);
 			DEBUG("In %s mcr=0x%x and up->port.mctrl=0x%x\n",__FUNCTION__,mcr,up->port.mctrl);
-			
+
 			up->mcr |= UART_MCR_AFE;
-			serial99100_set_mctrl(&up->port,up->port.mctrl);	
+			serial99100_set_mctrl(&up->port,up->port.mctrl);
 			mcr = serial_in(up,UART_MCR);
 			DEBUG("In %s mcr=0x%x and up->port.mctrl=0x%x\n",__FUNCTION__,mcr,up->port.mctrl);
-		}	
+		}
 
 		if (up->capabilities & UART_CAP_FIFO && uart_config[port->type].fifo_size > 1) {
 				fcr = uart_config[up->port.type].fcr;
@@ -1420,10 +1416,10 @@ static int serial99100_startup(struct uart_port *port)
 		}
 	}
 
-	
+
 	if((up->port.type == PORT_ENHANCED) || (up->custom_setting == 1)){
 		//Setting the Enhanced Mode Features
-		setserial_ENHANC_mode(up);		
+		setserial_ENHANC_mode(up);
 
 		if (up->capabilities & UART_CAP_FIFO && uart_config[port->type].fifo_size > 1) {
 			fcr = uart_config[up->port.type].fcr;
@@ -1473,10 +1469,10 @@ static int serial99100_startup(struct uart_port *port)
 				cks=serial_icr_read(up,UART_CKS);
 				cks |= 0x00;
 
-				//ACR - [4:3]-10 -> 0x10, 
+				//ACR - [4:3]-10 -> 0x10,
 				acr = 0x18;
 				break;
-				
+
 			case AX99100_RS485_HALF_DUPLEX_ECHO:
 				//Commset Registers Offset 0
 				//0x0008 0000  -19thBit -1 SW RS485 enable
@@ -1499,7 +1495,7 @@ static int serial99100_startup(struct uart_port *port)
 				cks = serial_icr_read(up,UART_CKS);
 				cks |= 0x00;
 
-				//ACR - [4:3]-11 -> 0x18, 
+				//ACR - [4:3]-11 -> 0x18,
 				acr = 0x18;
 				break;
 
@@ -1527,7 +1523,7 @@ static int serial99100_startup(struct uart_port *port)
 				cks = serial_icr_read(up,UART_CKS);
 				cks |= 0x00;
 
-				//ACR - 0x10, 
+				//ACR - 0x10,
 				acr = 0x10;
 				break;
 			case AX99100_RS485_FULL_DUPLEX:
@@ -1541,7 +1537,7 @@ static int serial99100_startup(struct uart_port *port)
 				DEBUG("TranceiverMode AX99100_RS485_MODE - RS485_FULL_DUPLEX\n");
 				ser_dcr_din_val = readl(up->port.membase+SP_SETTING_REG0);
 				ser_dcr_din_val &= 0xfff00fff;
-				ser_dcr_din_val |= 0x000A0000;			  
+				ser_dcr_din_val |= 0x000A0000;
 
 				//Commset Registers Offset 1
 				//0xff00 0000  -[31-24] ff
@@ -1553,7 +1549,7 @@ static int serial99100_startup(struct uart_port *port)
 				cks = serial_icr_read(up,UART_CKS);
 				cks |= 0x00;
 
-				//ACR - 0x10, 
+				//ACR - 0x10,
 				acr = 0x18;
 				break;
 			default:
@@ -1564,14 +1560,14 @@ static int serial99100_startup(struct uart_port *port)
 				break;
 		}
 
-		if(up->uart_mode > 0){	
+		if(up->uart_mode > 0){
 			up->acr = up->acr|acr;
 
 			writel(ser_dcr_din_val,up->port.membase+SP_SETTING_REG0);
 			writel(ser_ven_val,up->port.membase+SP_SETTING_REG1);
 			serial_icr_write(up,UART_CKS,cks);
 			serial_icr_write(up,UART_ACR,up->acr);
-			
+
 			DEBUG("SP_SETTING_REG0=0x%x   SP_SETTING_REG1=0x%x   UART_CKS=0x%x   UART_ACR=0x%x\n",
 				readl(up->port.membase+SP_SETTING_REG0),readl(up->port.membase+SP_SETTING_REG1),cks,up->acr);
 		}
@@ -1582,9 +1578,9 @@ static int serial99100_startup(struct uart_port *port)
 		up->acr |= UART_ACR_TLENB;
 		serial_icr_write(up,UART_ACR,up->acr);
 
-		//If Hardware Flow Control is to be enabled. The RTS/CTS, DTR/DSR is possible only in 232 mode. 
+		//If Hardware Flow Control is to be enabled. The RTS/CTS, DTR/DSR is possible only in 232 mode.
 		if(up->flow_control && up->uart_mode == AX99100_RS232_MODE){
-			
+
 			//Setting the auto hardware flow control trigger levels
 			serial_icr_write(up,UART_FCL,16);
 			serial_icr_write(up,UART_FCH,240);
@@ -1603,8 +1599,8 @@ static int serial99100_startup(struct uart_port *port)
 					}else{
 						DEBUG("No flow control enabled\n");
 						break;
-					}			
-					
+					}
+
 				case AX99100_XON_XOFF_HW_FLOWCONTROL:
 					DEBUG("Enabled HwFlowControl AX99100_XON_XOFF_HW_FLOWCONTROL\n");
 					if (up->mode_9bit != MODE_9BIT_SLAVE_HW) {
@@ -1629,15 +1625,15 @@ static int serial99100_startup(struct uart_port *port)
 					if(up->uart_mode == AX99100_RS232_MODE){
 						DEBUG("H/W Flow Control AX99100_RTS_CTS_HW_FLOWCONTROL enabled\n");
 						lcr = serial_in(up,UART_LCR);
-						serial_out(up,UART_LCR,0xBF);	
+						serial_out(up,UART_LCR,0xBF);
 						efr=serial_in(up,UART_EFR);
 						efr |= 0xD0;
-						serial_out(up,UART_EFR,efr);									
+						serial_out(up,UART_EFR,efr);
 						serial_out(up,UART_LCR,lcr);
-						
+
 						up->port.mctrl |= TIOCM_RTS;
 						serial99100_set_mctrl(&up->port, up->port.mctrl);
-						break;	
+						break;
 					}else{
 						DEBUG("No H/W flow control enabled\n");
 					}
@@ -1659,7 +1655,7 @@ static int serial99100_startup(struct uart_port *port)
 			serial_out(up,UART_XOFF2,up->nodeID_9bit);
 			serial_out(up,UART_EFR,efr);
 			serial_out(up,UART_LCR,lcr);
-		}		
+		}
 
 		// 2872 setup
 		if (up->ax99100_port_mode == AX99100_MF_PORT) {
@@ -1680,7 +1676,7 @@ static int serial99100_startup(struct uart_port *port)
 				if (up->uart_mode == AX99100_RS485_HALF_DUPLEX || up->uart_mode == AX99100_RS485_HALF_DUPLEX_ECHO)
 					offset3c0 |= (1 << 4);
 				else
-					offset3c0 &= ~(1 << 4);				
+					offset3c0 &= ~(1 << 4);
 
 				// FEN
 				if (up->ltc2872_fen == 1)
@@ -1699,7 +1695,7 @@ static int serial99100_startup(struct uart_port *port)
 				if (up->uart_mode == AX99100_RS485_HALF_DUPLEX || up->uart_mode == AX99100_RS485_HALF_DUPLEX_ECHO)
 					offset3c0 |= (1 << 1);
 				else
-					offset3c0 &= ~(1 << 1);				
+					offset3c0 &= ~(1 << 1);
 
 				// FEN
 				if (up->ltc2872_fen == 1)
@@ -1730,13 +1726,13 @@ static int serial99100_startup(struct uart_port *port)
 				ser_dcr_din_val &= ~(((unsigned char)1) << 31);
 
 			// 485/232
-			if (up->uart_mode == AX99100_RS232_MODE) {	
+			if (up->uart_mode == AX99100_RS232_MODE) {
 				ser_dcr_din_val &= ~(1 << 19);
 			} else {
 				ser_dcr_din_val |= (1 << 19);
 			}
-		}				
-		
+		}
+
 		if (up->uart_mode == AX99100_RS232_MODE) {
 			if (up->ax99100_port_mode == AX99100_MF_PORT)
 				ser_dcr_din_val |= (1 << 11);
@@ -1751,16 +1747,16 @@ static int serial99100_startup(struct uart_port *port)
 			MP_DBG(KERN_ERR"   set ser_dcr_din_val = 0x%x\n", ser_dcr_din_val);
 			MP_DBG(KERN_ERR"   re-read set ser_dcr_din_val = 0x%x\n", readl(up->port.membase + SP_SETTING_REG0));
 		}
-	}	
-	
+	}
+
 	/*
 	 * Finally, enable interrupts.  Note: Modem status interrupts
 	 * are set via set_termios(), which will be occurring imminently
 	 * anyway, so we don't enable them here.
 	 */
-	if(up->dma_rx || up->dma_tx){		
+	if(up->dma_rx || up->dma_tx){
 		writel(0xFE,up->port.membase+REG_GLBL_IER);
-		
+
 
 		if(up->dma_rx){
 			//Set the comset DMA register to enable DMA
@@ -1768,10 +1764,10 @@ static int serial99100_startup(struct uart_port *port)
 			ser_dcr_din_val=readl(up->port.membase+SP_SETTING_REG0);
 			ser_dcr_din_val |= COM_DMA_MODE_EN;
 			writel(ser_dcr_din_val,up->port.membase+SP_SETTING_REG0);
-			DEBUG("SP_SETTING_REG0=0x%x\n",readl(up->port.membase+SP_SETTING_REG0));	
+			DEBUG("SP_SETTING_REG0=0x%x\n",readl(up->port.membase+SP_SETTING_REG0));
 		}
 
-		
+
 		if (!up->dma_tx && up->dma_rx) {
 			serial_out(up,UART_IER, UART_IER_RDI | UART_IER_RLSI /*| UART_IER_MSI*/ | UART_IER_THRI);
 		} else {
@@ -1783,20 +1779,14 @@ static int serial99100_startup(struct uart_port *port)
 			writel(up->dma_rx_buf_p,up->port.membase+REG_RX_DMA_START_ADDRESS_LOW);
 			writel(0,up->port.membase+REG_RX_DMA_START_ADDRESS_HIGH);
 			writel(DMA_RX_SZ,up->port.membase+REG_RX_DMA_LENGTH);
-			writel(RX_DMA_START_BIT,up->port.membase+REG_RX_DMA_START);			
+			writel(RX_DMA_START_BIT,up->port.membase+REG_RX_DMA_START);
 			up->pre_need2recv_cnt = DMA_RX_SZ;
 		}
-		if(up->dma_tx)			
+		if(up->dma_tx)
 			writel(0,up->port.membase + REG_TX_DMA_START_ADDRESS_HIGH);
 	} else {
 		serial_out(up,UART_IER,UART_IER_THRI);
 	}
-
-	/*
-	 * Read back the current IER register, so the shadow value matches the current setting.
-	 * Timing is not that critical here.
-	 */
-	up->ier = serial_in(up, UART_IER);
 
 	/*
 	 * And clear the interrupt generating registers again for luck.
@@ -1835,7 +1825,7 @@ static void serial99100_shutdown(struct uart_port *port)
         DEBUG("iobase is 0x%x\n",up->port.iobase);
 
 	printk("No of Errors In ttyF%d brake=%d frame=%d parity=%d overrun=%d\n",
-		port->line, 
+		port->line,
 		port->icount.brk,
 		port->icount.frame,
 		port->icount.parity,
@@ -1857,7 +1847,7 @@ static void serial99100_shutdown(struct uart_port *port)
 	 */
 	up->ier = 0;
 	serial_out(up, UART_IER, 0);
-	
+
 	//tasklet kill
 	tasklet_kill(&up->tasklet_dma_rx);
 	tasklet_kill(&up->tasklet_dma_tx);
@@ -1897,7 +1887,7 @@ static void serial99100_shutdown(struct uart_port *port)
 	        DEBUG("mapbase is 0x%x\n",up->port.mapbase);
         	DEBUG("iobase is 0x%x\n",up->port.iobase);
 		up->acr = 0x00;
-	
+
 		// ENHANCED Mode reset
 		serial_icr_write(up, UART_CSR, 0x00);
 		serial_icr_write(up, UART_CSR, 0xFF);
@@ -1911,17 +1901,17 @@ static void serial99100_shutdown(struct uart_port *port)
 		ser_dcr_din_val=readl(up->port.membase+SP_SETTING_REG0);
 		ser_dcr_din_val &= ~(COM_DMA_MODE_EN);
 		writel(ser_dcr_din_val,up->port.membase+SP_SETTING_REG0);
-		DEBUG("SP_SETTING_REG0=0x%x\n",readl(up->port.membase+SP_SETTING_REG0));	
+		DEBUG("SP_SETTING_REG0=0x%x\n",readl(up->port.membase+SP_SETTING_REG0));
 	}
 	// Setup DXEN direction to input in RS485 mode
 	if (up->uart_mode != AX99100_RS232_MODE) {
 		writel(readl(up->port.membase + SP_SETTING_REG0) & ~(1 << 11) , up->port.membase + SP_SETTING_REG0);
-	}	
+	}
 
 	DEBUG("In %s --------------------------------------END\n",__FUNCTION__);
 }
 
-//This is a port ops helper function to return the divsor (baud_base / baud) for the selected baud rate 
+//This is a port ops helper function to return the divsor (baud_base / baud) for the selected baud rate
 //	specified by termios.
 static unsigned int serial99100_get_divisor(struct uart_port *port, unsigned int baud)
 {
@@ -1932,11 +1922,13 @@ static unsigned int serial99100_get_divisor(struct uart_port *port, unsigned int
 	quot = uart_get_divisor(port, baud);
 
 	DEBUG("In %s quot=%u----baud=%u-----------------------------END\n",__FUNCTION__,quot,baud);
-	return quot;	
+	return quot;
 }
 
 //This is a port ops function to set the terminal settings.
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,20)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+static void serial99100_set_termios(struct uart_port *port, struct ktermios *termios, const struct ktermios *old)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,20)
 static void serial99100_set_termios(struct uart_port *port, struct ktermios *termios, struct ktermios *old)
 #else
 static void serial99100_set_termios(struct uart_port *port, struct termios *termios, struct termios *old)
@@ -1946,14 +1938,14 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 	u8 cval,fcr=0;
 	unsigned long flags;
 	unsigned int baud, quot;
-	unsigned int source_select = 0;  //Internal 1=1.8382M 0=125M 
+	unsigned int source_select = 0;  //Internal 1=1.8382M 0=125M
 	unsigned int sampling_clock = 16; // 16:use default 16 bits sampling clock
 	u32 sp_clk_val = 0;
-	u32 internal_clk_val = 0;	
+	u32 internal_clk_val = 0;
 	u32 gpi0_3D4_value;
 
 	DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);
-	
+
 	switch (termios->c_cflag & CSIZE) {
 	case CS5:
 		cval = 0x00;
@@ -1980,36 +1972,36 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 	if (termios->c_cflag & CMSPAR)
 		cval |= UART_LCR_SPAR;
 #endif
-	
+
 	/*
 	 * Ask the core to calculate the divisor for us.
 	 */
-	
 
-	if (up->custom_setting == 1) {	
+
+	if (up->custom_setting == 1) {
 		if (!(readl(up->bar5membase + EDS_REG) & EDS_EOES) && up->baud_base_clock == CLK_EXTERNAL) {
 			printk("AX99100_SP:Extenal Oscillator does not exist!\n");
-			printk("AX99100_SP:Baud Rate setting: 115200\n");	
+			printk("AX99100_SP:Baud Rate setting: 115200\n");
 			up->baud_base_clock = 0x00;
 			baud = 115200;
 			up->custom_dlm = 0x00;
 			up->custom_dll = 0x01;
 			up->custom_sampling_clock = 0x10;
 		}
-	  
-		source_select = up->baud_base_clock;		
-		baud = up->custom_baud;	
-		BR_DBG(KERN_ERR"   (custom)function %d BaudRate = %d\n", up->function_number , baud);		
+
+		source_select = up->baud_base_clock;
+		baud = up->custom_baud;
+		BR_DBG(KERN_ERR"   (custom)function %d BaudRate = %d\n", up->function_number , baud);
 		switch (up->baud_base_clock) {
 			case CLK_125M:
 				port->uartclk = BASE_CLK_125M;
-				up->dma_delay_timeout = (5 * ((up->custom_dlm*256)+up->custom_dll) * 768)/1000+1;				
+				up->dma_delay_timeout = (5 * ((up->custom_dlm*256)+up->custom_dll) * 768)/1000+1;
 				break;
 			case CLK_EXTERNAL:
 				port->uartclk = BASE_CLK_24M;
 				if (CusEEbuffer.ext_clk != 0xFFFFFFFF)
 					port->uartclk = CusEEbuffer.ext_clk;
-					
+
 				up->dma_delay_timeout = (42 * ((up->custom_dlm*256)+up->custom_dll) * 768)/1000+1;
 				break;
 			case CLK_1_8382M:
@@ -2017,13 +2009,13 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 				port->uartclk = BASE_CLK_1_838235;
 				up->dma_delay_timeout = (540 * ((up->custom_dlm*256)+up->custom_dll) * 768)/1000+1;
 				break;
-		}		
+		}
 
-		sp_clk_val = (readl(up->port.membase + SP_BR_CLK_SEL_REG) & CLK_MASK) | source_select | 0x30;		
+		sp_clk_val = (readl(up->port.membase + SP_BR_CLK_SEL_REG) & CLK_MASK) | source_select | 0x30;
 		writel(sp_clk_val, up->port.membase + SP_BR_CLK_SEL_REG);
 		BR_DBG(KERN_ERR"   (custom)function %d SP_BR_CLK_SEL_REG = 0x%x\n",up->function_number , readl(up->port.membase + SP_BR_CLK_SEL_REG));
-		
-		if ( source_select == CLK_EXTERNAL ){		  
+
+		if ( source_select == CLK_EXTERNAL ){
 			do {
 				 mdelay(1);
 				 gpi0_3D4_value = readl(up->bar5membase + EDS_REG);
@@ -2031,15 +2023,15 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 					break;
 			} while (1);
 		}
-		
+
 		internal_clk_val = readl(up->bar5membase + 0x70);
 		if (source_select == CLK_1_8382M)
 			internal_clk_val |= (1 << up->function_number);
 		else
 			internal_clk_val &= ~(1 << up->function_number);
-  
+
 		BR_DBG(KERN_ERR"   (custom)function %d bar5 + 0x70 = 0x%X\n",up->function_number , internal_clk_val);
-		writel(internal_clk_val, up->bar5membase + 0x70);	
+		writel(internal_clk_val, up->bar5membase + 0x70);
 
 		BR_DBG(KERN_ERR"   (custom)function %d dlm = %d, dll = %d\n",up->function_number ,up->custom_dlm, up->custom_dll);
 		serial_out(up, UART_LCR, cval | UART_LCR_DLAB);	/* set DLAB */
@@ -2052,25 +2044,25 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 		BR_DBG(KERN_ERR"   (custom)function %d sampling clock = 0x%X\n",up->function_number ,sampling_clock);
 
 	} else {
-		port->uartclk = DEFAULT99100_BAUD * 16;	
+		port->uartclk = DEFAULT99100_BAUD * 16;
 		baud = uart_get_baud_rate(port, termios, old, 0, port->uartclk);
 		DEBUG("In %s -------------------baud=%u\n",__FUNCTION__,baud);
 		BR_DBG(KERN_ERR"   (standard)function %d BaudRate = %d\n",up->function_number , baud);
 		// default source_select = CLK_1_8382M
 		internal_clk_val = readl(up->bar5membase + 0x70);
 		internal_clk_val |= (1 << up->function_number);
-		
+
 		BR_DBG(KERN_ERR"   (standard)function %d bar5 + 0x70 = 0x%X\n",up->function_number , internal_clk_val);
 		writel(internal_clk_val, up->bar5membase + 0x70);
 
 		// default source_select = CLK_1_8382M
-		source_select	= CLK_1_8382M;		
-		
+		source_select	= CLK_1_8382M;
+
 		if(baud > 115200) {
 
 			quot = 1;
 
-			switch (baud) {				
+			switch (baud) {
 				case 230400:
 					port->uartclk = BASE_CLK_125M;
 					source_select = CLK_125M;
@@ -2109,17 +2101,17 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 				case 2000000:
 					port->uartclk = BASE_CLK_24M;
 					source_select = CLK_EXTERNAL;
-					sampling_clock = 12;					
+					sampling_clock = 12;
 					break;
 				case 3000000:
 					port->uartclk = BASE_CLK_24M;
 					source_select = CLK_EXTERNAL;
-					sampling_clock = 8;					
+					sampling_clock = 8;
 					break;
 				case 4000000:
 					port->uartclk = BASE_CLK_24M;
 					source_select = CLK_EXTERNAL;
-					sampling_clock = 6;					
+					sampling_clock = 6;
 					break;
 				default:
 					printk("Now setup baud rate = 115200 bps.\n");
@@ -2127,7 +2119,7 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 			}
 		} else {
 			quot = serial99100_get_divisor(port, baud);
-		}		
+		}
 
 		sp_clk_val = (readl(up->port.membase + SP_BR_CLK_SEL_REG) & CLK_MASK) | source_select | 0x30;
 		BR_DBG(KERN_ERR"   (standard)function %d SP_BR_CLK_SEL_REG = 0x%X\n",up->function_number , sp_clk_val);
@@ -2150,7 +2142,7 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 		else
 			fcr = uart_config[up->port.type].fcr;
 	}
-	
+
 	/*
 	 * MCR-based auto flow control.  When AFE is enabled, RTS will be
 	 * deasserted when the receive FIFO contains more characters than
@@ -2231,10 +2223,10 @@ static void serial99100_set_termios(struct uart_port *port, struct termios *term
 		if (fcr & UART_FCR_ENABLE_FIFO) {
 			/* emulated UARTs (Lucent Venus 167x) need two steps */
 			serial_out(up, UART_FCR, UART_FCR_ENABLE_FIFO);
-			
+
 		}
 		serial_out(up,UART_FCR,fcr);		/* set fcr */
-		DEBUG("In %s UART_FCR is written with fcr=0x%x\n",__FUNCTION__,fcr);	
+		DEBUG("In %s UART_FCR is written with fcr=0x%x\n",__FUNCTION__,fcr);
 	}
 
 	serial_icr_write(up, UART_TCR, sampling_clock);
@@ -2272,9 +2264,9 @@ static void serial99100_release_port(struct uart_port *port)
 {
 	struct uart_99100_port *up = &serial99100_ports[port->line];
 	DEBUG("In %s---------------------------------------START\n",__FUNCTION__);
-	
+
 	iounmap(up->port.membase);
-	
+
 	DEBUG("In %s---------------------------------------END\n",__FUNCTION__);
 }
 
@@ -2294,10 +2286,10 @@ static int serial99100_request_port(struct uart_port *port)
 		ret = -EBUSY;
 		goto release;
 	}
-	
+
 	DEBUG("In %s---------------------------------------END\n",__FUNCTION__);
 	return ret;
-	
+
 release:
 #if defined(__x86_64__) || defined(__amd64__)
 	release_region(up->port.iobase,size);
@@ -2318,13 +2310,13 @@ static void serial99100_getCustomModeFromEeprom(struct uart_99100_port *port)
 	unsigned short sum, i;
 	unsigned char index;
 	u8 *tmp = (u8*) &CusEEbuffer;
-	
-	
+
+
 	DEBUG("AX99100: serial99100_getCustomModeFromEeprom #C\n");
-	
+
 	index = 0x28; 	//Device I2C address, we should have a way to determine address
 	offset = 0x60;
-	
+
 	if(!port->bar5membase)
 	{
 		DEBUG("AX99100: GPIO/EEPROM base address not found\n");
@@ -2335,11 +2327,11 @@ static void serial99100_getCustomModeFromEeprom(struct uart_99100_port *port)
 		DEBUG("REG_I2CSCLCR %08X\n", readl(port->bar5membase + REG_I2CSCLCR));
 		DEBUG("REG_I2CBFTR %08X\n", readl(port->bar5membase + REG_I2CBFTR));
 	}
-	
 
-	for (i = 0; i < CUSTOM_EEPROM_LEN; i++) 
+
+	for (i = 0; i < CUSTOM_EEPROM_LEN; i++)
 	{
-		unsigned long start;			
+		unsigned long start;
 #if EEPROM8BIT
 		writeValue = ((index << 25) | (offset << 8)) & (~(1 << 24)); //8bits
 #else
@@ -2349,7 +2341,7 @@ static void serial99100_getCustomModeFromEeprom(struct uart_99100_port *port)
 		start = jiffies;
 		do {
 			writel(writeValue, port->bar5membase + REG_I2CCR);
-			
+
 			if (time_after(jiffies, start + HZ / 100)) {
 				DEBUG("AX99100: I2CSCLCR_CHECK error %08X\n",
 					readl(port->bar5membase + REG_I2CSCLCR));
@@ -2359,10 +2351,10 @@ static void serial99100_getCustomModeFromEeprom(struct uart_99100_port *port)
 		} while(readl(port->bar5membase + REG_I2CSCLCR) & I2CSCLCR_CHECK);
 
 		*(tmp + i) = (u8)(readl(port->bar5membase + REG_I2CCR) & 0xFF);
-		
+
 		DEBUG("AX99100: eBuffer[%d]:%02X\n", i, *(tmp + i));
 		offset++;
-		
+
 		writeValue = 0x0;
 	}
 	if(CusEEbuffer.cus_mod == 0xFFFF) {
@@ -2387,7 +2379,7 @@ static void serial99100_getCustomModeFromEeprom(struct uart_99100_port *port)
 	}
 	if (sum >> 8)
 		sum = ((sum >> 8) & 0x00FF) + (sum & 0x00FF);
-		
+
 	if (sum != 0x79)
 	{
 		DEBUG("AX99100: incorrect checksum\n");
@@ -2406,8 +2398,8 @@ void serial99100_serialSettingGPIO(struct uart_99100_port *up)
 	GpioSetValueGroup1 = ((SetGpioValue & 2) >> 1) | ((SetGpioValue & 8) >> 2);
 	GpioSetValueGroup2 = ((SetGpioValue & 0x10) >> 3) | ((SetGpioValue & 0x40) >> 6);
 	GpioSetValueGroup3 = ((SetGpioValue & 0x20) >> 4) | ((SetGpioValue & 0x80) >> 7);
-    
-	if (!up->oriDTR) {   
+
+	if (!up->oriDTR) {
 		TtempValue = 0;
 		INIT_DBG(KERN_ERR "ASUS 485 Mode\n");
 
@@ -2415,7 +2407,7 @@ void serial99100_serialSettingGPIO(struct uart_99100_port *up)
             		TtempValue = 2;
 			GpioSetValueGroup0 = 0x0;
 			GpioSetValueGroup2 = 0x0 | TtempValue;
-		    
+
 		} else if (up->function_number == 3) {
 			TtempValue = 2;
 			GpioSetValueGroup1 = 0x0;
@@ -2433,7 +2425,7 @@ void serial99100_serialSettingGPIO(struct uart_99100_port *up)
 		writel(lSetGpioValue, up->bar5membase + REG_GPIOPIN);      //Set Value
 		SetGpioValue = lSetGpioValue;
 		writel((unsigned long)0x04, up->port.membase + SP_GPIO_ENABLE_REG); //Enable
-		
+
 		if (up->oriCTS == 1) {
 			//RS485_HALF_DUPLEX
 			writel((unsigned long)0x24, up->port.membase + SP_GPIO_ENABLE_REG);
@@ -2448,7 +2440,7 @@ void serial99100_serialSettingGPIO(struct uart_99100_port *up)
 
 		INIT_DBG(KERN_ERR "CtsInitValue = 0x%x.\r\n", up->oriCTS);
 
-		
+
 
 	} else {
 		INIT_DBG(KERN_ERR "ASUS 232 Mode\n");
@@ -2475,7 +2467,7 @@ void serial99100_serialSettingGPIO(struct uart_99100_port *up)
 		writel((unsigned long)(0xFFFF00), up->bar5membase + REG_GPIODIR);
 		writel(lSetGpioValue, up->bar5membase + REG_GPIOPIN);
 		SetGpioValue = lSetGpioValue;
-	}               
+	}
 }
 
 static int serial99100_ioctl(struct uart_port *port, unsigned int cmd, unsigned long arg)
@@ -2506,9 +2498,9 @@ static int serial99100_ioctl(struct uart_port *port, unsigned int cmd, unsigned 
 		__put_user(up->ax99100_port_mode, p);
 		break;
         case IOCTL_SET_PARAMETER:
-		up->baud_base_clock = (arg >> 20) & 0xFF;		
-		up->custom_dlm = (arg >> 12) & 0xFF;		
-		up->custom_dll = (arg >> 4) & 0xFF;				
+		up->baud_base_clock = (arg >> 20) & 0xFF;
+		up->custom_dlm = (arg >> 12) & 0xFF;
+		up->custom_dll = (arg >> 4) & 0xFF;
 		break;
 	case IOCTL_SET_SAMPLING:
 		up->custom_sampling_clock = (arg >> 0);
@@ -2527,7 +2519,7 @@ static int serial99100_ioctl(struct uart_port *port, unsigned int cmd, unsigned 
 	case IOCTL_GPIO_OUTPUT:
 		gpio_output_99100 = arg & 0xFF;
 		writel(gpio_output_99100, up->bar5membase + 0x3C0);
-		break;	 
+		break;
 	case IOCTL_GET_EDS_EOES: /* 2016/08/02 For ext_clk */
 		eds = readl(up->bar5membase + EDS_REG) & 0x0F000000;
 		__put_user(eds, p);
@@ -2537,7 +2529,7 @@ static int serial99100_ioctl(struct uart_port *port, unsigned int cmd, unsigned 
 			return -ENOIOCTLCMD;
 		serial_out(up, UART_SCR, (start_value & 0x01));
 		break;
-	case IOCTL_SET_SLAVE_MODE: /* 9-bit mode */		
+	case IOCTL_SET_SLAVE_MODE: /* 9-bit mode */
 		if(copy_from_user(&slave, p, sizeof(slave)))
 			return -ENOIOCTLCMD;
 		if (slave.slave_mode >= MODE_9BIT_DISABLE &&
@@ -2548,12 +2540,12 @@ static int serial99100_ioctl(struct uart_port *port, unsigned int cmd, unsigned 
 			    up->mode_9bit == MODE_9BIT_SLAVE_SW ||
 			    up->mode_9bit == MODE_9BIT_DATA) {
 				/* Enable 9 bit */
-				serial_icr_write(up, UART_NMR , (NMR_NBE | NMR_NBIE));	
-				
+				serial_icr_write(up, UART_NMR , (NMR_NBE | NMR_NBIE));
+
 				val=readl(up->port.membase + SP_SETTING_REG0);
 				val &= 0xDFFFFFFF;
 				val |= 0x20000000;
-				writel(val, up->port.membase + SP_SETTING_REG0);			
+				writel(val, up->port.membase + SP_SETTING_REG0);
 			} else if (up->mode_9bit == MODE_9BIT_SLAVE_HW) {
 				/* Enable 9 bit & addesss mode */
 				serial_icr_write(up, UART_NMR , (NMR_NBE | NMR_NBIE | NMR_AME));
@@ -2565,10 +2557,10 @@ static int serial99100_ioctl(struct uart_port *port, unsigned int cmd, unsigned 
 
 				lcr = serial_in(up,UART_LCR);
 				serial_out(up,UART_LCR,0xBF);
-				efr=serial_in(up,UART_EFR);			
+				efr=serial_in(up,UART_EFR);
 				serial_out(up,UART_XOFF2,up->nodeID_9bit);
 				serial_out(up,UART_EFR,efr);
-				serial_out(up,UART_LCR,lcr);				
+				serial_out(up,UART_LCR,lcr);
 			} else {
 				/* Disable 9 bit */
 				serial_icr_write(up, UART_NMR , 0);
@@ -2576,10 +2568,10 @@ static int serial99100_ioctl(struct uart_port *port, unsigned int cmd, unsigned 
 				up->nodeID_9bit = 0;
 			}
 		}
-		
+
 		break;
 	default:
-		return -ENOIOCTLCMD;	
+		return -ENOIOCTLCMD;
 	}
 
 	return 0;
@@ -2650,9 +2642,9 @@ static int transmit_chars_dma_done(struct uart_99100_port * up);
 static void serial99100_dma_rx_tasklet (unsigned long param)
 {
 	struct uart_99100_port *up = (struct uart_99100_port *) param;
-	
+
 	u8 iir = serial_in(up, UART_IIR);
-	
+
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,26))
 	struct tty_struct *tty=up->port.info->tty;
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32)
@@ -2660,7 +2652,7 @@ static void serial99100_dma_rx_tasklet (unsigned long param)
 #else
 	struct tty_struct *tty = up->port.state->port.tty;
 #endif
-	
+
 	receive_chars_dma_done(up,up->k_gir);
 
 	if (!(iir & UART_IIR_NO_INT)) {
@@ -2684,9 +2676,9 @@ static void serial99100_dma_rx_tasklet (unsigned long param)
 			} else if (up->k_lsr & UART_LSR_OE) {
 				up->port.icount.overrun++;
 						//Mask off conditions which should be ignored.
-				up->k_lsr &= up->port.read_status_mask;		
+				up->k_lsr &= up->port.read_status_mask;
 			}
-		}	
+		}
 		if (up->k_lsr & ~up->port.ignore_status_mask & UART_LSR_OE)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,0)
 			tty_insert_flip_char(tty->port, 0, TTY_OVERRUN);
@@ -2722,7 +2714,7 @@ static struct uart_driver starex_serial_driver = {
 int serial99100_find_match_or_unused(struct uart_port *port)
 {
 	int i;
-	
+
 	/*
 	 * We didn't find a matching entry, so look for the first
 	 * free entry.  We look for one which hasn't been previously
@@ -2733,7 +2725,7 @@ int serial99100_find_match_or_unused(struct uart_port *port)
 		if (serial99100_ports[i].port.iobase == 0){
 			return i;
 			}
-	}	
+	}
 #endif
 	/*
 	 * That also failed.  Last resort is to find any entry which
@@ -2742,8 +2734,8 @@ int serial99100_find_match_or_unused(struct uart_port *port)
 	for (i = 0; i < UART99100_NR; i++){
 		if (serial99100_ports[i].port.type == PORT_UNKNOWN){
 			return i;
-			}	
-	}		
+			}
+	}
 	return -1;
 }
 
@@ -2752,7 +2744,7 @@ int serial99100_register_port(struct uart_port *port,struct pci_dev *dev)
 {
 	unsigned long base, len;
 	int index,ret = -ENOSPC, i = 0;
-	
+
 	if (port->uartclk == 0)
 		return -EINVAL;
 
@@ -2824,10 +2816,10 @@ int serial99100_register_port(struct uart_port *port,struct pci_dev *dev)
 
 			// Setup the GPIO = out to control 2872
 			if (serial99100_ports[index].function_number == 0) {
-				writel(readl(serial99100_ports[index].bar5membase + 0x3C4) & 0xFFFFFFC7, 
+				writel(readl(serial99100_ports[index].bar5membase + 0x3C4) & 0xFFFFFFC7,
 					serial99100_ports[index].bar5membase + 0x3C4);
 			} else if (serial99100_ports[index].function_number == 2) {
-				writel(readl(serial99100_ports[index].bar5membase + 0x3C4) & 0xFFFFFFF8, 
+				writel(readl(serial99100_ports[index].bar5membase + 0x3C4) & 0xFFFFFFF8,
 					serial99100_ports[index].bar5membase + 0x3C4);
 			}
 			INIT_DBG(KERN_ERR"   0x3C4 = 0x%x\n", readl(serial99100_ports[index].bar5membase + 0x3C4));
@@ -2854,16 +2846,16 @@ int serial99100_register_port(struct uart_port *port,struct pci_dev *dev)
 			uart_99100_contxts[index].rx_dma_en = 0;
 			serial99100_ports[index].mode_9bit = uart_99100_contxts[index].mode_9bit;
 			serial99100_ports[index].nodeID_9bit = uart_99100_contxts[index].nodeID_9bit;
-		}	
-		
+		}
+
 		if (uart_99100_contxts[index].tx_dma_en == 1) {
 			serial99100_ports[index].dma_tx=1;
 
-			serial99100_ports[index].dma_tx_buf_v =
-				(char *)pci_alloc_consistent(dev,DMA_TX_BUFFER_SZ,&serial99100_ports[index].dma_tx_buf_p);
-			serial99100_ports[index].dma_tx_buf_v_start =
-				(char *)pci_alloc_consistent(dev,DMA_TX_BUFFER_SZ,&serial99100_ports[index].dma_tx_buf_p_start);
-			
+			serial99100_ports[index].dma_tx_buf_v = (char *)dma_alloc_coherent(
+			    &(dev->dev), DMA_TX_BUFFER_SZ,&serial99100_ports[index].dma_tx_buf_p,GFP_KERNEL);
+			serial99100_ports[index].dma_tx_buf_v_start = (char *)dma_alloc_coherent(
+			    &(dev->dev),DMA_TX_BUFFER_SZ,&serial99100_ports[index].dma_tx_buf_p_start,GFP_KERNEL);
+
 			memset(serial99100_ports[index].dma_tx_buf_v,0,DMA_TX_BUFFER_SZ);
 			memset(serial99100_ports[index].dma_tx_buf_v_start,0,DMA_TX_BUFFER_SZ);
 
@@ -2877,20 +2869,20 @@ int serial99100_register_port(struct uart_port *port,struct pci_dev *dev)
 			serial99100_ports[index].dma_tx_buf_v=NULL;
 			serial99100_ports[index].dma_tx_buf_v_start=NULL;
 		}
-		
+
 		if (uart_99100_contxts[index].rx_dma_en == 1) {
 			serial99100_ports[index].dma_rx=1;
-			serial99100_ports[index].dma_rx_buf_v =
-				(char *)pci_alloc_consistent(dev,DMA_RX_BUFFER_SZ,&serial99100_ports[index].dma_rx_buf_p);
-			memset(serial99100_ports[index].dma_rx_buf_v,0,DMA_RX_BUFFER_SZ);			
-			serial99100_ports[index].part_done_recv_cnt=0;	
+			serial99100_ports[index].dma_rx_buf_v =	(char *)dma_alloc_coherent(
+			    &(dev->dev),DMA_RX_BUFFER_SZ,&serial99100_ports[index].dma_rx_buf_p,GFP_KERNEL);
+			memset(serial99100_ports[index].dma_rx_buf_v,0,DMA_RX_BUFFER_SZ);
+			serial99100_ports[index].part_done_recv_cnt=0;
 			serial99100_ports[index].rx_dma_done_cnt=0;
 			DEBUG("dma_rx_buf_v=0x%x\n dma_rx_buf_p=0x%x\n",(unsigned int)serial99100_ports[index].dma_rx_buf_v,
 				(unsigned int)serial99100_ports[index].dma_rx_buf_p);
 		} else {
 			serial99100_ports[index].dma_rx=0;
 			serial99100_ports[index].dma_rx_buf_v=NULL;
-		}		
+		}
 
 		serial99100_ports[index].uart_mode = uart_99100_contxts[index].uart_mode;
 		serial99100_ports[index].flow_control = uart_99100_contxts[index].en_flow_control;
@@ -2918,7 +2910,7 @@ int serial99100_register_port(struct uart_port *port,struct pci_dev *dev)
 			serial99100_ports[index].custom_dlm		= CusEEbuffer.pt_setting[i].dlm;
 			serial99100_ports[index].custom_sampling_clock =
 					(!CusEEbuffer.pt_setting[i].sample_rate ? 4 : CusEEbuffer.pt_setting[i].sample_rate);
-			serial99100_ports[index].custom_dll = (!CusEEbuffer.pt_setting[i].dll ? 1 : CusEEbuffer.pt_setting[i].dll); 
+			serial99100_ports[index].custom_dll = (!CusEEbuffer.pt_setting[i].dll ? 1 : CusEEbuffer.pt_setting[i].dll);
 
 			switch (serial99100_ports[index].baud_base_clock) {
 				case CLK_125M:
@@ -2937,44 +2929,44 @@ int serial99100_register_port(struct uart_port *port,struct pci_dev *dev)
 
 			serial99100_ports[index].custom_baud = uartclk / (serial99100_ports[index].custom_sampling_clock *
 					(serial99100_ports[index].custom_dlm * 256 + serial99100_ports[index].custom_dll));
-			
+
 		}
 
 		if ((CusEEbuffer.cus_mod == CUS_ASUS) && (serial99100_ports[index].function_number > 1)) {
 			serial99100_ports[index].oriDTR = (readl(serial99100_ports[index].bar5membase + EDE_REG) >> 24) & 0xF;
 			serial99100_ports[index].oriDTR >>= serial99100_ports[index].function_number;
 			serial99100_ports[index].oriDTR &= 1;
-			writel((unsigned long)0x04, serial99100_ports[index].port.membase + SP_GPIO_ENABLE_REG); //Enable	
+			writel((unsigned long)0x04, serial99100_ports[index].port.membase + SP_GPIO_ENABLE_REG); //Enable
 			serial99100_ports[index].oriCTS = (readl(serial99100_ports[index].port.membase + SP_GPIO_INPUT_REG) >> 2) & 1;
 			serial99100_serialSettingGPIO(&serial99100_ports[index]);
 			INIT_DBG(KERN_ERR "function %d oriDTR %d oriCTS %d\n", serial99100_ports[index].function_number,
 					 serial99100_ports[index].oriDTR, serial99100_ports[index].oriCTS);
 		}
-		
+
 		if (uart_99100_contxts[index].uart_mode == AX99100_RS485_FULL_DUPLEX ||
   			uart_99100_contxts[index].uart_mode == AX99100_RS485_HALF_DUPLEX ||
 			uart_99100_contxts[index].uart_mode == AX99100_RS485_HALF_DUPLEX_ECHO ||
 			uart_99100_contxts[index].uart_mode == AX99100_RS422_MODE ||
 			uart_99100_contxts[index].uart_mode == AX99100_IRDA_MODE) {
-			
+
 			serial99100_ports[index].port.type = PORT_ENHANCED;
 			serial99100_ports[index].rxfifotrigger = uart_99100_contxts[index].rxfifotrigger;
-			serial99100_ports[index].txfifotrigger = uart_99100_contxts[index].txfifotrigger;			
+			serial99100_ports[index].txfifotrigger = uart_99100_contxts[index].txfifotrigger;
 		}
-		
+
 		if (serial99100_ports[index].flow_control && (serial99100_ports[index].uart_mode == AX99100_RS232_MODE)) {
-			if (uart_99100_contxts[index].flow_ctrl_type == AX99100_DTR_DSR_HW_FLOWCONTROL || 
-				uart_99100_contxts[index].flow_ctrl_type == AX99100_XON_XOFF_HW_FLOWCONTROL || 
+			if (uart_99100_contxts[index].flow_ctrl_type == AX99100_DTR_DSR_HW_FLOWCONTROL ||
+				uart_99100_contxts[index].flow_ctrl_type == AX99100_XON_XOFF_HW_FLOWCONTROL ||
 				uart_99100_contxts[index].flow_ctrl_type == AX99100_RTS_CTS_HW_FLOWCONTROL) {
 				serial99100_ports[index].port.type = PORT_ENHANCED;
 				serial99100_ports[index].rxfifotrigger = uart_99100_contxts[index].rxfifotrigger;
-				serial99100_ports[index].txfifotrigger = uart_99100_contxts[index].txfifotrigger;		
+				serial99100_ports[index].txfifotrigger = uart_99100_contxts[index].txfifotrigger;
 			}
 		}
 
 		if (serial99100_ports[index].port.type == PORT_ENHANCED) {
 			serial99100_ports[index].rxfifotrigger = uart_99100_contxts[index].rxfifotrigger;
-			serial99100_ports[index].txfifotrigger = uart_99100_contxts[index].txfifotrigger;		
+			serial99100_ports[index].txfifotrigger = uart_99100_contxts[index].txfifotrigger;
 		}
 	}
 	up(&serial99100_sem);
@@ -2984,7 +2976,7 @@ int serial99100_register_port(struct uart_port *port,struct pci_dev *dev)
 
 
 static struct pci_device_id serial99100_pci_tbl[] = {
-	//{PCI_VENDOR_ID_NETMOS, PCI_ANY_ID, PCI_SUBDEV_ID_AX99100, PCI_SUBVEN_ID_AX99100, 0, 0, 0},	
+	//{PCI_VENDOR_ID_NETMOS, PCI_ANY_ID, PCI_SUBDEV_ID_AX99100, PCI_SUBVEN_ID_AX99100, 0, 0, 0},
 	{0x125B, 0x9100, PCI_SUBDEV_ID_AX99100, PCI_SUBVEN_ID_AX99100_SP, 0, 0, 0},
 	{0, },
 };
@@ -3003,8 +2995,8 @@ static void __devexit serial99100_remove_one(struct pci_dev *dev)
 	if  (dev->subsystem_device != PCI_SUBVEN_ID_AX99100_SP) {
 		dev_err(&dev->dev, "Not AX99100 SP device when remove!\n");
 		return;
-	} 
-	
+	}
+
 	base = pci_resource_start(dev, FL_BASE1);
 
 	for (i = 0; i < UART99100_NR; i++){
@@ -3020,15 +3012,15 @@ static void __devexit serial99100_remove_one(struct pci_dev *dev)
 		DEBUG("value at address 3FC is %x\n",readl(uart->port.membase + 0x3FC));
 		writel(1,uart->port.membase + 0x3FC);
 		DEBUG("value at address 3FC after configuring is %x\n",readl(uart->port.membase + 0x3FC));
-	
+
 		down(&serial99100_sem);
 		uart_remove_one_port(&starex_serial_driver, &uart->port);
-		uart->port.dev = NULL;		
+		uart->port.dev = NULL;
 		up(&serial99100_sem);
-		
-		pci_free_consistent(dev,DMA_TX_BUFFER_SZ,uart->dma_tx_buf_v,uart->dma_tx_buf_p);
-		pci_free_consistent(dev,DMA_TX_BUFFER_SZ,uart->dma_tx_buf_v_start,uart->dma_tx_buf_p_start);
-		pci_free_consistent(dev,DMA_RX_BUFFER_SZ,uart->dma_rx_buf_v,uart->dma_rx_buf_p);
+
+		dma_free_coherent(&(dev->dev),DMA_TX_BUFFER_SZ,uart->dma_tx_buf_v,uart->dma_tx_buf_p);
+		dma_free_coherent(&(dev->dev),DMA_TX_BUFFER_SZ,uart->dma_tx_buf_v_start,uart->dma_tx_buf_p_start);
+		dma_free_coherent(&(dev->dev),DMA_RX_BUFFER_SZ,uart->dma_rx_buf_v,uart->dma_rx_buf_p);
 		pci_disable_device(dev);
 
 		//Initialise the uart_99100_port arrays port specific element to the default state
@@ -3051,7 +3043,7 @@ static int __devinit serial99100_probe(struct pci_dev *dev,
 	int retval;
 
 	retval = pci_enable_device(dev);
-	
+
 	if (retval) {
 		dev_err(&dev->dev, "Device enable FAILED\n");
 		return retval;
@@ -3080,7 +3072,7 @@ static int __devinit serial99100_probe(struct pci_dev *dev,
 		goto disable;
 	}
 
-	pci_set_master(dev);	
+	pci_set_master(dev);
 
 	memset(&serial_port, 0, sizeof(struct uart_port));
 	memset(&CusEEbuffer,0, CUSTOM_EEPROM_LEN);
@@ -3089,12 +3081,12 @@ static int __devinit serial99100_probe(struct pci_dev *dev,
 	serial_port.uartclk = DEFAULT99100_BAUD * 16;
 	serial_port.irq = dev->irq;
 	serial_port.dev = &dev->dev;
-	
+
 	len =  pci_resource_len(dev, FL_BASE1);
 	base = pci_resource_start(dev, FL_BASE1);
 	serial_port.mapbase = base;
 	serial_port.membase = ioremap(base,len);
-	
+
 
 	DEBUG("membase=0x%x\n mapbase=0x%x\n",(unsigned int)serial_port.membase,(unsigned int)serial_port.mapbase);
 	DEBUG("value at address 3FC is %x\n",readl(serial_port.membase + 0x3FC));
@@ -3109,21 +3101,21 @@ static int __devinit serial99100_probe(struct pci_dev *dev,
 	retval = serial99100_register_port(&serial_port,dev);
 	if (retval < 0){
 		DEBUG(KERN_WARNING "Couldn't register serial port %s, retval=%d: \n", pci_name(dev),retval);
-		goto disable;	
-	}	
+		goto disable;
+	}
 
 //Register an ISR
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24)
-	if ((retval = request_irq(dev->irq, serial99100_interrupt,SA_SHIRQ,"AX99100",&serial99100_ports[retval]))) 
+	if ((retval = request_irq(dev->irq, serial99100_interrupt,SA_SHIRQ,"AX99100",&serial99100_ports[retval])))
 		goto disable;
 #else
-	if ((retval = request_irq(dev->irq, serial99100_interrupt,IRQF_SHARED,"AX99100",&serial99100_ports[retval]))) 
+	if ((retval = request_irq(dev->irq, serial99100_interrupt,IRQF_SHARED,"AX99100",&serial99100_ports[retval])))
 		goto disable;
 #endif
 	printk(version);
 
-	return 0;	
-	 
+	return 0;
+
 disable:
 	return retval;
 }
@@ -3190,7 +3182,7 @@ static int serial99100_resume(struct pci_dev *dev)
 	int i;
 	unsigned long base;
 	struct uart_99100_port *uart = NULL;
-	
+
 	pci_set_power_state(dev, PCI_D0);
 	pci_restore_state(dev);
 	pci_enable_wake(dev, PCI_D0, 0);
@@ -3234,7 +3226,7 @@ static int serial99100_resume(struct pci_dev *dev)
 	return 0;
 };
 
-	
+
 static struct pci_driver starex_pci_driver = {
 	.name		= "AX99100",
 	.probe		= serial99100_probe,
@@ -3255,17 +3247,17 @@ static int __init serial99100_init(void)
 	int ret;
 
 	DEBUG("In %s---------------------------------------START\n",__FUNCTION__);
-	
-	
+
+
 
 	serial99100_init_ports();
-	
+
 	ret = uart_register_driver(&starex_serial_driver);
 	if (ret){
 		DEBUG("In %s uart_register_driver FAILED\n",__FUNCTION__);
 		return ret;
-	}		
-	
+	}
+
 	ret = spi99100_init();
 	if (ret < 0){
 		DEBUG("In %s spi_register_driver FAILED\n",__FUNCTION__);
@@ -3277,7 +3269,7 @@ static int __init serial99100_init(void)
 		DEBUG("In %s pci_register_driver FAILED\n",__FUNCTION__);
 		uart_unregister_driver(&starex_serial_driver);
 	}
-	
+
 	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
 	return ret;
 }
@@ -3289,7 +3281,7 @@ static void __exit serial99100_exit(void)
 	pci_unregister_driver(&starex_pci_driver);
 	spi99100_exit();
 	uart_unregister_driver(&starex_serial_driver);
-	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);	
+	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
 }
 
 module_init(serial99100_init);

--- a/ax99100_spi.c
+++ b/ax99100_spi.c
@@ -76,7 +76,7 @@ int spi_suspend_count;
 static unsigned int spi_major = 241;
 static unsigned int spi_min_count = 0;
 /* device Class */
-static char *ax_devnode(struct device *dev, umode_t *mode)
+static char *ax_devnode(const struct device *dev, umode_t *mode)
 {
 	return kasprintf(GFP_KERNEL, "%s", dev_name(dev));
 }
@@ -94,21 +94,21 @@ struct spi_99100 {
 	unsigned int		dev_major;
 	unsigned int		dev_minor;
 	char 			dev_name[64];
-	
+
 	unsigned long		iobase0;			// bar0
 	unsigned char __iomem	*membase[2];			// 0: bar1 1:bar5
 	resource_size_t		mapbase[2];			// for ioremap
-	
+
 
 	unsigned int		irq;
 
-	
+
 	char 	*		tx_dma_v;			//Virtual Address of DMA Buffer for TX
 	dma_addr_t 		tx_dma_p;			//Physical Address of DMA Buffer for TX
 	char 	*		rx_dma_v;			//Virtual Address of DMA Buffer for RX
 	dma_addr_t 		rx_dma_p;			//Physical Address of DMA Buffer for RX
 
-	int 			tool_pid;	
+	int 			tool_pid;
 };
 
 static int		 init_cdev = 0;
@@ -123,19 +123,19 @@ PSPI_DMA 	dma[NUM_DEVICE];
 /* memmap read reg */
 static _INLINE_ u32 ax99100_dread_mem_reg(int offset, int bar, int line)
 {
-       return readl(axspi_device[line]->membase[bar] + offset);	
+       return readl(axspi_device[line]->membase[bar] + offset);
 }
 
 /* memmap write reg */
 static _INLINE_ void ax99100_dwrite_mem_reg(int offset, int value, int bar, int line)
 {
-	writel(value, axspi_device[line]->membase[bar] + offset);	
+	writel(value, axspi_device[line]->membase[bar] + offset);
 }
 
 /* iomap read reg */
 static _INLINE_ u8 ax99100_dread_io_reg(unsigned char offset, int line)
 {
-       return inb(axspi_device[line]->iobase0 + offset);	
+       return inb(axspi_device[line]->iobase0 + offset);
 }
 
 /* iomap write reg */
@@ -145,45 +145,45 @@ static _INLINE_ void ax99100_dwrite_io_reg(unsigned char offset,unsigned char va
 }
 
 /******************************************************
- * 
+ *
  * File Operation
- * 
+ *
  * ****************************************************/
 
 static long spi99100_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	int line = MINOR(*((dev_t*)filp->private_data));
-	unsigned long	length;	
+	unsigned long	length;
 	PSPI_REG	preg = reg[line];
 	PMMAP_SPI_REG	preg_m = reg_m[line];
 	PSPI_DMA 	pdma = dma[line];
 	struct spi_99100* axspi = NULL;
 
-	axspi = axspi_device[line];	
-	
-	switch (cmd) {	
+	axspi = axspi_device[line];
+
+	switch (cmd) {
 	case IOCTL_IO_SET_REGISTER:
-	{			
+	{
 		if(copy_from_user(preg, (PSPI_REG)arg, sizeof(SPI_REG)))
 			return -ENOIOCTLCMD;
-		
+
 		ax99100_dwrite_io_reg(preg->Offset, preg->Value, line);
 
 		DEBUG("IOCTL_IO_SET_REGISTER Offset: 0x%x Value: 0x%x\n", preg->Offset, preg->Value);
 		break;
 	}
 	case IOCTL_IO_READ_REGISTER:
-	{			
+	{
 		DEBUG("IOCTL_IO_READ_REGISTER\n");
 		if(copy_from_user(preg, (PSPI_REG)arg, sizeof(SPI_REG)))
 			return -ENOIOCTLCMD;
-		
+
 		preg->Value = ax99100_dread_io_reg(preg->Offset, line);
-		
+
 		if(copy_to_user((PSPI_REG)arg, preg, sizeof(SPI_REG)))
 			return -ENOIOCTLCMD;
-		
-		
+
+
 		break;
 	}
 	case IOCTL_MEM_SET_REGISTER:
@@ -191,7 +191,7 @@ static long spi99100_ioctl(struct file *filp, unsigned int cmd, unsigned long ar
 		DEBUG("IOCTL_MEM_SET_REGISTER\n");
 		if(copy_from_user(preg_m, (PMMAP_SPI_REG)arg, sizeof(MMAP_SPI_REG)))
 			return -ENOIOCTLCMD;
-		
+
 		ax99100_dwrite_mem_reg(preg_m->Offset, preg_m->Value, preg_m->Bar, line);
 		break;
 	}
@@ -200,12 +200,12 @@ static long spi99100_ioctl(struct file *filp, unsigned int cmd, unsigned long ar
 		DEBUG("IOCTL_MEM_READ_REGISTER\n");
 		if(copy_from_user(preg_m, (PMMAP_SPI_REG)arg, sizeof(MMAP_SPI_REG)))
 			return -ENOIOCTLCMD;
-	  
+
 		preg_m->Value = ax99100_dread_mem_reg(preg_m->Offset, preg_m->Bar, line);
-		
+
 		if(copy_to_user((PMMAP_SPI_REG)arg, preg_m, sizeof(MMAP_SPI_REG)))
 			return -ENOIOCTLCMD;
-		
+
 		break;
 	}
 	case IOCTL_SET_TX_DMA_REG:
@@ -213,25 +213,25 @@ static long spi99100_ioctl(struct file *filp, unsigned int cmd, unsigned long ar
 		DEBUG("IOCTL_SET_TX_DMA_REG\n");
 		if(copy_from_user(&length, (unsigned long *)arg, sizeof(unsigned long)))
 			return -ENOIOCTLCMD;
-		
+
 		ax99100_dwrite_mem_reg(REG_TDMASAR0, axspi->tx_dma_p, BAR1, line);
 		ax99100_dwrite_mem_reg(REG_TDMASAR1, 0x0, BAR1, line);
 		ax99100_dwrite_mem_reg(REG_TDMALR, length, BAR1, line);
 		ax99100_dwrite_mem_reg(REG_TDMASTAR, START_DMA, BAR1, line);
-		
+
 		break;
 	}
 	case IOCTL_SET_RX_DMA_REG:
 	{
 		DEBUG("IOCTL_SET_RX_DMA_REG\n");
 		if(copy_from_user(&length, (unsigned long *)arg, sizeof(unsigned long)))
-			return -ENOIOCTLCMD;	  
-		
+			return -ENOIOCTLCMD;
+
 		ax99100_dwrite_mem_reg(REG_RDMASAR0, axspi->rx_dma_p, BAR1, line);
 		ax99100_dwrite_mem_reg(REG_RDMASAR1, 0x0, BAR1, line);
 		ax99100_dwrite_mem_reg(REG_RDMALR, length, BAR1, line);
 		ax99100_dwrite_mem_reg(REG_RDMASTAR, START_DMA, BAR1, line);
-		
+
 		break;
 	}
 	case IOCTL_TX_DMA_WRITE:
@@ -239,27 +239,27 @@ static long spi99100_ioctl(struct file *filp, unsigned int cmd, unsigned long ar
 		DEBUG("IOCTL_TX_DMA_WRITE\n");
 		if(copy_from_user(pdma, (PSPI_DMA)arg, sizeof(SPI_DMA)))
 			return -ENOIOCTLCMD;
-		
+
 		memcpy_toio(axspi->tx_dma_v, pdma->Buffer, pdma->Length);
-		
+
 		break;
 	}
 	case IOCTL_RX_DMA_READ:
-	{		
+	{
 		DEBUG("IOCTL_RX_DMA_READ\n");
 		if(copy_from_user(pdma, (PSPI_DMA)arg, sizeof(SPI_DMA)))
 			return -ENOIOCTLCMD;
-		
-		memcpy_fromio(pdma->Buffer, axspi->rx_dma_v, pdma->Length);		
-		
+
+		memcpy_fromio(pdma->Buffer, axspi->rx_dma_v, pdma->Length);
+
 		if(copy_to_user((PSPI_DMA)arg, pdma, sizeof(SPI_DMA)))
 			return -ENOIOCTLCMD;
-		
+
 		break;
 	}
 
 	default:
-		return -ENOIOCTLCMD;	
+		return -ENOIOCTLCMD;
 	}
 	return 0;
 }
@@ -269,31 +269,31 @@ static int spi99100_open (struct inode *inop, struct file *filp)
 	struct cdev*	cdev = inop->i_cdev;
 	int 		line = MINOR(cdev->dev);
 
-	filp->private_data = &cdev->dev;	
+	filp->private_data = &cdev->dev;
 
 	reg[line] = kmalloc(sizeof(SPI_REG), GFP_KERNEL);
 	if (reg[line] == NULL) {
 		goto err;
 	}
-	memset(reg[line], 0xFF, sizeof(SPI_REG));	
-	
+	memset(reg[line], 0xFF, sizeof(SPI_REG));
+
 	reg_m[line] = kmalloc(sizeof(MMAP_SPI_REG), GFP_KERNEL);
 	if (reg_m[line]== NULL) {
 		goto err;
 	}
-	memset(reg_m[line], 0xFF, sizeof(MMAP_SPI_REG));	
-	
+	memset(reg_m[line], 0xFF, sizeof(MMAP_SPI_REG));
+
 	dma[line] = kmalloc(sizeof(SPI_DMA), GFP_KERNEL);
 	if (dma[line]== NULL) {
 		goto err;
 	}
-	memset(dma[line], 0xFF, sizeof(SPI_DMA));	
+	memset(dma[line], 0xFF, sizeof(SPI_DMA));
 
 	return 0;
 err:
 	if (!reg[line])
 		kfree(reg[line]);
-	if (!reg_m[line]) 
+	if (!reg_m[line])
 		kfree(reg_m[line]);
 	if (!dma[line])
 		kfree(dma[line]);
@@ -307,25 +307,25 @@ static int spi99100_release (struct inode *inop, struct file *filp)
 	kfree(reg[line]);
 	kfree(reg_m[line]);
 	kfree(dma[line]);
-	
+
 	return 0;
 }
 
 static struct file_operations bridge_fops = {
-	.owner		=	THIS_MODULE,	
-	.unlocked_ioctl	=	spi99100_ioctl,	
+	.owner		=	THIS_MODULE,
+	.unlocked_ioctl	=	spi99100_ioctl,
 	.open		=	spi99100_open,
 	.release	=	spi99100_release,
 };
 /********************************************************************
- * 
+ *
  * NETLINK
- * 
+ *
  ********************************************************************/
 void netlink_get(struct sk_buff *__skb) {
- 	
+
 	struct nlmsghdr *nlh = NULL;
-	char str[100];	
+	char str[100];
 	int line;
 
         if (__skb->len >= NLMSG_SPACE(0)) {
@@ -344,7 +344,7 @@ void netlink_sendmsg(struct spi_99100* axspi)
 	struct nlmsghdr *nlh;
 	int		ret;
 	int 		pid = axspi->tool_pid;
-	
+
 	char msg[30] = "Interrupt Complete!";
 
 	if (!nl_sk)
@@ -357,22 +357,22 @@ void netlink_sendmsg(struct spi_99100* axspi)
 
 	nlh = nlmsg_put(skb, 0, 0, 0, MAX_PAYLOAD_SIZE, 0);
 
-	memcpy(NLMSG_DATA(nlh), msg, sizeof(msg));	
+	memcpy(NLMSG_DATA(nlh), msg, sizeof(msg));
 
-	ret = netlink_unicast(nl_sk, skb, pid, MSG_DONTWAIT);	
+	ret = netlink_unicast(nl_sk, skb, pid, MSG_DONTWAIT);
 	if (ret < 0) {
 		printk("Netlink sends failed.\n");
 	}
 }
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)	
-struct netlink_kernel_cfg netlink_kerncfg = {		
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
+struct netlink_kernel_cfg netlink_kerncfg = {
 		        .input = netlink_get,
 		    };
 #endif
 /********************************************************************
- * 
+ *
  * PCIE FUNCTION
- * 
+ *
  ********************************************************************/
 
 //PCI driver remove function. Rlease the resources used by the port
@@ -385,33 +385,33 @@ static void __devexit spi99100_remove_one(struct pci_dev *dev)
 	dev_t	device;
 	struct spi_99100*	axspi = NULL;
 
-	DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);	
+	DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);
 
 	axspi = (struct spi_99100*)pci_get_drvdata(dev);
-	
+
 	device = MKDEV(axspi->dev_major, axspi->dev_minor);
 
 	/* DMA free */
-	pci_free_consistent(dev, DMA_BUFFER_SZ, axspi->tx_dma_v,axspi->tx_dma_p);
-	pci_free_consistent(dev, DMA_BUFFER_SZ, axspi->rx_dma_v,axspi->rx_dma_p);
-	
+	dma_free_coherent(&(dev->dev), DMA_BUFFER_SZ, axspi->tx_dma_v,axspi->tx_dma_p);
+	dma_free_coherent(&(dev->dev), DMA_BUFFER_SZ, axspi->rx_dma_v,axspi->rx_dma_p);
+
 	if  (dev->subsystem_device != PCI_SUBVEN_ID_AX99100_SPI) {
 		dev_err(&dev->dev, "Not AX99100 SPI device when remove!\n");
 		return;
-	} 
-	
+	}
+
 	/* Remove Char Device & Class */
 	device_destroy(&ax_spi_class, device);
-	cdev_del(&axspi->spi);	
+	cdev_del(&axspi->spi);
 	if (init_cdev == 1) {
 		dev_t	device_tmp = MKDEV(axspi->dev_major, 0);
 		unregister_chrdev_region(device_tmp, NUM_DEVICE);
 		init_cdev = 0;
 	}
-	
+
 	/* Remove netlink setting */
 	if (nl_sk != NULL) {
-		sock_release(nl_sk->sk_socket);	
+		sock_release(nl_sk->sk_socket);
 		nl_sk = NULL;
 	}
 
@@ -420,7 +420,7 @@ static void __devexit spi99100_remove_one(struct pci_dev *dev)
 	pci_disable_device(dev);
 
 	kfree(axspi);
-	
+
 	DEBUG("In %s---------------------------------------END\n",__FUNCTION__);
 }
 
@@ -429,7 +429,7 @@ void init_local_data(struct pci_dev *dev)
 	struct spi_99100*	axspi = NULL;
 	unsigned long		base, len;
 
-	DEBUG("In %s---------------------------------------START\n",__FUNCTION__);	
+	DEBUG("In %s---------------------------------------START\n",__FUNCTION__);
 
 	axspi = (struct spi_99100*)pci_get_drvdata(dev);
 
@@ -444,39 +444,39 @@ void init_local_data(struct pci_dev *dev)
 	base = pci_resource_start(dev, FL_BASE5);
 	axspi->mapbase[1] = base;
 	axspi->membase[1] = ioremap(base,len);
-	
-	
+
+
 	DEBUG("bar1 membase=0x%x mapbase=0x%x\n",
 		(unsigned int)axspi->membase[0],(unsigned int)axspi->mapbase[0]);
 	DEBUG("bar5 membase=0x%x mapbase=0x%x\n",
 		(unsigned int)axspi->membase[1],(unsigned int)axspi->mapbase[1]);
-	
+
 	/* io map */
 	base = pci_resource_start(dev,FL_BASE0);
 	axspi->iobase0 = base;
-	
-	DEBUG("bar0 iobase=0x%x\n",(unsigned int)axspi->iobase0);	
-	
-	
+
+	DEBUG("bar0 iobase=0x%x\n",(unsigned int)axspi->iobase0);
+
+
 	/* DMA for TX */
-	axspi->tx_dma_v =
-		(char *)pci_alloc_consistent(dev,DMA_BUFFER_SZ,&axspi->tx_dma_p);
+	axspi->tx_dma_v = (char *)dma_alloc_coherent(
+	    &(dev->dev),DMA_BUFFER_SZ,&axspi->tx_dma_p,GFP_KERNEL);
 	memset(axspi->tx_dma_v,0,DMA_BUFFER_SZ);
-	
+
 	DEBUG("tx_dma_v=0x%x tx_dma_p=0x%x\n",(unsigned int)axspi->tx_dma_v,
 		(unsigned int)axspi->tx_dma_p);
-	
+
 	/* DMA for RX */
-	axspi->rx_dma_v =
-		(char *)pci_alloc_consistent(dev,DMA_BUFFER_SZ,&axspi->rx_dma_p);
+	axspi->rx_dma_v = (char *)dma_alloc_coherent(
+	    &(dev->dev),DMA_BUFFER_SZ,&axspi->rx_dma_p,GFP_KERNEL);
 	memset(axspi->rx_dma_v,0,DMA_BUFFER_SZ);
-	
+
 	DEBUG("rx_dma_v=0x%x rx_dma_p=0x%x\n",(unsigned int)axspi->rx_dma_v,
 		(unsigned int)axspi->rx_dma_p);
-	
 
-	
-	
+
+
+
 	DEBUG("In %s---------------------------------------END\n",__FUNCTION__);
 }
 
@@ -489,23 +489,23 @@ static irqreturn_t spi99100_interrupt(int irq, void *dev_id, struct pt_regs *reg
 	int line = 0;
 	int handled = 0;
 	unsigned long isr_status = 0;
-	unsigned long sdcr = 0;	
+	unsigned long sdcr = 0;
 	struct spi_99100* axspi = (struct spi_99100*)dev_id;
 
 	DEBUG("In %s---------------------------------------START\n",__FUNCTION__);
 
-	line = axspi->dev_minor;	
+	line = axspi->dev_minor;
 
 	DEBUG("In %s---------line: %d\n",__FUNCTION__, line);
-	
-	
-	/* Read SDCR */	
-	sdcr = ax99100_dread_io_reg(REG_SDCR, line);	
+
+
+	/* Read SDCR */
+	sdcr = ax99100_dread_io_reg(REG_SDCR, line);
 	if (!(sdcr & INTERRUPT_ENABLE_MASK))
 		return IRQ_RETVAL(0);
-	
-	/* Read ISR */	
-	isr_status = ax99100_dread_io_reg(REG_SPIMISR, line);	
+
+	/* Read ISR */
+	isr_status = ax99100_dread_io_reg(REG_SPIMISR, line);
 	if (!(isr_status & INTERRUPT_MASK))
 		return IRQ_RETVAL(0);
 
@@ -534,7 +534,7 @@ static irqreturn_t spi99100_interrupt(int irq, void *dev_id, struct pt_regs *reg
 /* helper function to reset device connect to spi */
 void spi_reset(int line)
 {
-	ax99100_dwrite_mem_reg(REG_SWRST, SW_RESET, BAR1, line);	
+	ax99100_dwrite_mem_reg(REG_SWRST, SW_RESET, BAR1, line);
 }
 
 static void axspi_line_name(int index, char *p)
@@ -543,56 +543,56 @@ static void axspi_line_name(int index, char *p)
 }
 
 static int register_char_device (struct spi_99100 *spi_device)
-{	 
+{
 	dev_t		dev = MKDEV(spi_major, spi_min_count);
-	struct cdev*	spi = &spi_device->spi;	
+	struct cdev*	spi = &spi_device->spi;
 	int		alloc_ret = 0,cdev_ret = 0;
-	struct device 	*device = NULL;	
+	struct device 	*device = NULL;
 
 	memset(spi,0,sizeof(struct cdev));
 
 	if (init_cdev == 0) {
 		alloc_ret = alloc_chrdev_region(&dev, 0, NUM_DEVICE, DEV_NAME);
 		if (alloc_ret) {
-			DEBUG("alloc_chrdev_region Failed.\n");		
+			DEBUG("alloc_chrdev_region Failed.\n");
 			goto disable;
 		}
 		spi_major = MAJOR(dev);
 		init_cdev++;
-	}	
-	
+	}
+
 	spi_device->dev_major = MAJOR(dev);
 	spi_device->dev_minor = MINOR(dev);
-	DEBUG("maj: %d,min: %d\n",spi_device->dev_major,spi_device->dev_minor);	
+	DEBUG("maj: %d,min: %d\n",spi_device->dev_major,spi_device->dev_minor);
 
 	axspi_line_name(spi_device->dev_minor, spi_device->dev_name);
 
-	DEBUG("device name: %s\n", spi_device->dev_name);	
-	
+	DEBUG("device name: %s\n", spi_device->dev_name);
+
 	device = device_create(&ax_spi_class, NULL, dev, NULL, spi_device->dev_name);
-	
-	if (IS_ERR(device)) { 
-		DEBUG("device_create Failed %ld.\n",PTR_ERR(device));	
+
+	if (IS_ERR(device)) {
+		DEBUG("device_create Failed %ld.\n",PTR_ERR(device));
 		goto disable;
-	}	
-	
+	}
+
 	cdev_init(spi, &bridge_fops);
 	spi->owner 	= THIS_MODULE;
 	spi->ops	= &bridge_fops;
-	cdev_ret = cdev_add(spi, dev, 1);	
+	cdev_ret = cdev_add(spi, dev, 1);
 	if (cdev_ret) {
 		DEBUG("cdev_add Failed.\n");
 		goto disable;
-	}		
-	
+	}
+
 	spi_min_count++;
 	return 1;
-	
+
 disable:
 	if (cdev_ret != 0)
 		cdev_del(spi);
 	if (device != NULL)
-		device_destroy(&ax_spi_class, dev);	
+		device_destroy(&ax_spi_class, dev);
 	if (alloc_ret != 0)
 		unregister_chrdev_region(dev, 1);
 	return -1;
@@ -605,8 +605,8 @@ static int __devinit spi99100_probe(struct pci_dev *dev, const struct pci_device
 #endif
 {
 	struct spi_99100*	axspi = NULL;
-	int 			retval, ret;	
-	
+	int 			retval, ret;
+
 	printk(version_spi);
 
 	DEBUG("In %s---------------------------------------START\n",__FUNCTION__);
@@ -620,13 +620,13 @@ static int __devinit spi99100_probe(struct pci_dev *dev, const struct pci_device
 	pci_set_drvdata(dev, axspi);
 
 	memset(axspi,0,sizeof(struct spi_99100));
-	
-	retval = pci_enable_device(dev);		
-	
+
+	retval = pci_enable_device(dev);
+
 	if (retval) {
 		dev_err(&dev->dev, "Device enable FAILED\n");
                 return retval;
-	}	
+	}
 
 	/* To verify whether it is a local bus communication hardware */
 	if ((dev->class >> 16) != PCI_CLASS_OTHERS){
@@ -634,18 +634,18 @@ static int __devinit spi99100_probe(struct pci_dev *dev, const struct pci_device
 		retval = -ENODEV;
 		goto disable;
 	}
-	
+
 	/* Initial Netlink sock */
-	if (nl_sk == NULL) { 	
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)	
+	if (nl_sk == NULL) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
 		nl_sk = netlink_kernel_create(&init_net,NETLINK_TEST, &netlink_kerncfg);
 #else
-		nl_sk = netlink_kernel_create(&init_net,NETLINK_TEST, 0, netlink_get, NULL, THIS_MODULE);	
-#endif	
+		nl_sk = netlink_kernel_create(&init_net,NETLINK_TEST, 0, netlink_get, NULL, THIS_MODULE);
+#endif
 	}
 
 	DEBUG("In %s nl_sk: 0x%x\n",__FUNCTION__ , nl_sk);
-	
+
 	ret = register_char_device(axspi);
 
 	axspi_device[axspi->dev_minor] = axspi;
@@ -655,33 +655,33 @@ static int __devinit spi99100_probe(struct pci_dev *dev, const struct pci_device
 		  DEBUG("In %s char_device_register FAILED\n",__FUNCTION__);
 		  return -1;
 	}
-	
-	pci_set_master(dev);	
-	
-	init_local_data(dev);	
+
+	pci_set_master(dev);
+
+	init_local_data(dev);
 
 	spi_reset(axspi->dev_minor);
-	
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24)
 	if ((retval = request_irq(dev->irq, spi99100_interrupt,
-				  SA_SHIRQ,"ax99100_spi", axspi))) 
+				  SA_SHIRQ,"ax99100_spi", axspi)))
 		goto disable;
 #else
 	if ((retval = request_irq(dev->irq, spi99100_interrupt,
-				IRQF_SHARED,"ax99100_spi", axspi))) 
+				IRQF_SHARED,"ax99100_spi", axspi)))
 		goto disable;
 #endif
 
 	axspi->irq = dev->irq;
 
-	printk("%s at I/O 0x%x (irq = %d) is a AX99100 SPI\n", 
-			axspi->dev_name, 
-			(unsigned int)axspi->iobase0, 
+	printk("%s at I/O 0x%x (irq = %d) is a AX99100 SPI\n",
+			axspi->dev_name,
+			(unsigned int)axspi->iobase0,
 			axspi->irq);
 
 	DEBUG("In %s---0-----------------------------------END\n",__FUNCTION__);
-	return 0;	
-	 
+	return 0;
+
 disable:
 	pci_disable_device(dev);
 	DEBUG("In %s---1-----------------------------------END\n",__FUNCTION__);
@@ -713,7 +713,7 @@ static int spi99100_suspend(struct pci_dev *dev, pm_message_t state)
 static int spi99100_resume(struct pci_dev *dev)
 {
 	u16 data;
-	
+
 	pci_set_power_state(dev, PCI_D0);
 	pci_restore_state(dev);
 	pci_enable_wake(dev, PCI_D0, 0);
@@ -755,41 +755,41 @@ static struct pci_driver starex_spi_driver = {
 };
 /* Drivers entry function. register with the pci core */
 int spi99100_init(void)
-{	
+{
 	int ret;
-	
-	
-	
-	DEBUG("In %s---------------------------------------START\n",__FUNCTION__);	
+
+
+
+	DEBUG("In %s---------------------------------------START\n",__FUNCTION__);
 
 	ret = class_register(&ax_spi_class);
 	if (ret) {
 		DEBUG("unable to register ax spi class\n");
 		return ret;
-	}		
-	
+	}
+
 	ret = pci_register_driver(&starex_spi_driver);
 	if (ret < 0){
 		DEBUG("In %s pci_register_driver FAILED\n",__FUNCTION__);
 		goto err;
 	}
-	
-	
+
+
 	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
-	
+
 	return ret;
 err:
 	class_unregister(&ax_spi_class);
-	return ret;	
+	return ret;
 }
 
 /* Drivers exit function. Unregister with the PCI core as well as serial core */
 void spi99100_exit(void)
-{	
+{
 	DEBUG("In %s ---------------------------------------START\n",__FUNCTION__);
-	
+
 	pci_unregister_driver(&starex_spi_driver);
 	class_unregister(&ax_spi_class);
-	
-	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);	
+
+	DEBUG("In %s ---------------------------------------END\n",__FUNCTION__);
 }


### PR DESCRIPTION
Hello Dave!  I had some trouble with the ax99100 driver under Kernel 6.2.0... The wrappers for the (deprecated) pci_{alloc,free}_consistent functions are gone, and the prototype for the 'set_termios' function has changed.

I switched to dma_{alloc,free}_coherent() functions with GFP_KERNEL level, since the allocations are not in IRQ handlers and shouldn't need atomic constraints. (Functions available since kernel 2.30, so I don't think there's a backward compatibility issue!)

