### PR TITLE
definition of "DEFINE_SEMAPHORE()" macro changed with kernel 6.4.0

### DIFF
--- a/ax99100_sp.c
+++ b/ax99100_sp.c
@@ -2697,8 +2697,10 @@ static void serial99100_dma_tx_tasklet (unsigned long param)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,37)
 static DECLARE_MUTEX(serial99100_sem);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
 static DEFINE_SEMAPHORE(serial99100_sem);
+#else
+static DEFINE_SEMAPHORE(serial99100_sem, 1);
 #endif
 
 static struct uart_driver starex_serial_driver = {


### PR DESCRIPTION
Hi Dave! The kernel guys did it again ;) With kernel v6.4.0 the definition of  "DEFINE_SEMAPHORE(s)" changed to "DEFINE_SEMAPHORE(s,v)". Had to put in another preprocessor conditional branch for that. Would be swell if you could merge that to your repo...